### PR TITLE
Rename binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@
 cscope.out
 tags
 
-/mavlink_router
+/mavlink-routerd
 /heartbeat_print

--- a/Makefile.am
+++ b/Makefile.am
@@ -118,8 +118,8 @@ AM_LDFLAGS = \
 	-Wl,--no-undefined \
 	-Wl,--gc-sections
 
-bin_PROGRAMS += mavlink_router
-mavlink_router_SOURCES = \
+bin_PROGRAMS += mavlink-routerd
+mavlink_routerd_SOURCES = \
 	comm.cpp \
 	comm.h \
 	log.c \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install:
 To route mavlink packets from master `ttyS1` to 2 other UDP endpoints, do as
 following:
 
-    $ mavlink_router -b 1500000 -e 192.168.7.1:14550 -e 127.0.0.1:14550 /dev/ttyS1
+    $ mavlink-routerd -b 1500000 -e 192.168.7.1:14550 -e 127.0.0.1:14550 /dev/ttyS1
 
 The `-b` switch above is used to set the UART baudrate. See more options with
-`mavlink_router --help`
+`mavlink-routerd --help`

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ(2.64)
-AC_INIT([mavlink_router],
+AC_INIT([mavlink-router],
 	[1],
 	[],
-	[mavlink_router],
+	[mavlink-router],
 	[])
 
 AC_CONFIG_SRCDIR([main.cpp])


### PR DESCRIPTION
Use dash instead of underscore and suffix with 'd' to stand for its
primary use case: running as a daemon.