### PR TITLE
Cleanup mavlink header parsing

### DIFF
--- a/examples/heartbeat-print.cpp
+++ b/examples/heartbeat-print.cpp
@@ -37,7 +37,7 @@ static void exit_signal_handler(int signum)
 
 static void setup_signal_handlers()
 {
-    struct sigaction sa = { };
+    struct sigaction sa = {};
 
     sa.sa_flags = SA_NOCLDSTOP;
     sa.sa_handler = exit_signal_handler;
@@ -53,8 +53,7 @@ static void handle_new_message(const mavlink_message_t *msg)
         printf("HEARTBEAT:\n"
                "\tmavlink_version: %u\n"
                "\ttype: %u\n",
-               heartbeat.mavlink_version,
-               heartbeat.type);
+               heartbeat.mavlink_version, heartbeat.type);
     }
 }
 
@@ -115,7 +114,6 @@ int main(int argc, char *argv[])
                 handle_new_message(&msg);
             }
         }
-
     }
 
     free(ip);

--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -108,7 +108,7 @@ int BinLog::write_msg(const struct buffer *buffer)
     }
 
     /* Check if we should start or stop logging */
-    _handle_auto_start_stop(msg_id, source_system_id, source_component_id, payload);
+    _handle_auto_start_stop(buffer);
 
     /* Check if we are interested in this msg_id */
     if (msg_id != MAVLINK_MSG_ID_REMOTE_LOG_DATA_BLOCK) {

--- a/src/comm.h
+++ b/src/comm.h
@@ -27,4 +27,18 @@
 struct buffer {
     unsigned int len;
     uint8_t *data;
+
+    /*
+     * Data relevant for the last parsed msg available on this buffer,
+     * copied from @data when we have a complete header
+     */
+    struct {
+        uint32_t msg_id;
+        int target_sysid;
+        int target_compid;
+        uint8_t src_sysid;
+        uint8_t src_compid;
+        uint8_t payload_len;
+        uint8_t *payload;
+    } curr;
 };

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -348,7 +348,7 @@ int Endpoint::read_msg(struct buffer *pbuf)
             _stat.read.crc_error_bytes += expected_size;
             return 0;
         }
-        _add_sys_comp_id(((uint16_t)src_sysid << 8) | src_compid);
+        _add_sys_comp_id(src_sysid, src_compid);
     }
 
     _stat.read.handled++;
@@ -405,8 +405,10 @@ int Endpoint::read_msg(struct buffer *pbuf)
     return msg_entry != nullptr ? ReadOk : ReadUnkownMsg;
 }
 
-void Endpoint::_add_sys_comp_id(uint16_t sys_comp_id)
+void Endpoint::_add_sys_comp_id(uint8_t sysid, uint8_t compid)
 {
+    uint16_t sys_comp_id = ((uint16_t)sysid << 8) | compid;
+
     if (has_sys_comp_id(sys_comp_id)) {
         return;
     }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -377,6 +377,9 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
         *msg_id = msg_entry->msgid;
     }
 
+    pbuf->curr
+        = {*msg_id, *target_sysid, *target_compid, *src_sysid, *src_compid, payload_len, payload};
+
     // Check for sequence drops
     if (_stat.read.expected_seq != seq) {
         if (_stat.read.total > 1) {

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -191,11 +191,7 @@ int Endpoint::handle_read()
             break;
         }
 
-        Mainloop::get_instance().route_msg(&buf, buf.curr.target_sysid,
-                                           buf.curr.target_compid,
-                                           buf.curr.src_sysid,
-                                           buf.curr.src_compid,
-                                           buf.curr.msg_id);
+        Mainloop::get_instance().route_msg(&buf);
     }
 
     return r;

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -182,27 +182,33 @@ bool Endpoint::handle_canwrite()
 
 int Endpoint::handle_read()
 {
-    int target_sysid, target_compid, r;
-    uint8_t src_sysid, src_compid;
-    uint32_t msg_id;
-    struct buffer buf {
-    };
+    struct buffer buf = {};
+    int r;
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id))
-           > 0) {
-        Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid, src_compid,
-                                           msg_id);
+    for (;;) {
+        r = read_msg(&buf);
+        if (r <= 0) {
+            break;
+        }
+
+        Mainloop::get_instance().route_msg(&buf, buf.curr.target_sysid,
+                                           buf.curr.target_compid,
+                                           buf.curr.src_sysid,
+                                           buf.curr.src_compid,
+                                           buf.curr.msg_id);
     }
 
     return r;
 }
 
-int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                       uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
+int Endpoint::read_msg(struct buffer *pbuf)
 {
     bool should_read_more = true;
     const mavlink_msg_entry_t *msg_entry;
     uint8_t *payload, seq, payload_len;
+    int target_sysid, target_compid;
+    uint8_t src_sysid, src_compid;
+    uint32_t msg_id;
 
     if (fd < 0) {
         log_error("%s %s: Trying to read invalid fd", _type.c_str(), _name.c_str());
@@ -290,11 +296,11 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
             return 0;
         }
 
-        *msg_id = hdr->msgid;
+        msg_id = hdr->msgid;
         payload = rx_buf.data + sizeof(*hdr);
         seq = hdr->seq;
-        *src_sysid = hdr->sysid;
-        *src_compid = hdr->compid;
+        src_sysid = hdr->sysid;
+        src_compid = hdr->compid;
         payload_len = hdr->payload_len;
 
         expected_size = sizeof(*hdr);
@@ -310,11 +316,11 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
             return 0;
         }
 
-        *msg_id = hdr->msgid;
+        msg_id = hdr->msgid;
         payload = rx_buf.data + sizeof(*hdr);
         seq = hdr->seq;
-        *src_sysid = hdr->sysid;
-        *src_compid = hdr->compid;
+        src_sysid = hdr->sysid;
+        src_compid = hdr->compid;
         payload_len = hdr->payload_len;
 
         expected_size = sizeof(*hdr);
@@ -333,7 +339,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
     _last_packet_len = expected_size;
     _stat.read.total++;
 
-    msg_entry = mavlink_get_msg_entry(*msg_id);
+    msg_entry = mavlink_get_msg_entry(msg_id);
     if (msg_entry) {
         /*
          * It is accepting and forwarding unknown messages ids because
@@ -346,39 +352,38 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
             _stat.read.crc_error_bytes += expected_size;
             return 0;
         }
-        _add_sys_comp_id(((uint16_t)*src_sysid << 8) | *src_compid);
+        _add_sys_comp_id(((uint16_t)src_sysid << 8) | src_compid);
     }
 
     _stat.read.handled++;
     _stat.read.handled_bytes += expected_size;
 
-    *target_sysid = -1;
-    *target_compid = -1;
+    target_sysid = -1;
+    target_compid = -1;
 
     if (msg_entry == nullptr) {
-        log_debug("%s [%d]%s: No message entry for %u", _type.c_str(), fd, _name.c_str(), *msg_id);
+        log_debug("%s [%d]%s: No message entry for %u", _type.c_str(), fd, _name.c_str(), msg_id);
     } else {
         if (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM) {
             // if target_system is 0, it may have been trimmed out on mavlink2
             if (msg_entry->target_system_ofs < payload_len) {
-                *target_sysid = payload[msg_entry->target_system_ofs];
+                target_sysid = payload[msg_entry->target_system_ofs];
             } else {
-                *target_sysid = 0;
+                target_sysid = 0;
             }
         }
         if (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT) {
             // if target_system is 0, it may have been trimmed out on mavlink2
             if (msg_entry->target_component_ofs < payload_len) {
-                *target_compid = payload[msg_entry->target_component_ofs];
+                target_compid = payload[msg_entry->target_component_ofs];
             } else {
-                *target_compid = 0;
+                target_compid = 0;
             }
         }
-        *msg_id = msg_entry->msgid;
+        msg_id = msg_entry->msgid;
     }
 
-    pbuf->curr
-        = {*msg_id, *target_sysid, *target_compid, *src_sysid, *src_compid, payload_len, payload};
+    pbuf->curr = {msg_id, target_sysid, target_compid, src_sysid, src_compid, payload_len, payload};
 
     // Check for sequence drops
     if (_stat.read.expected_seq != seq) {
@@ -763,10 +768,9 @@ bool UartEndpoint::_change_baud_cb(void *data)
     return true;
 }
 
-int UartEndpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                           uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
+int UartEndpoint::read_msg(struct buffer *pbuf)
 {
-    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid, msg_id);
+    int ret = Endpoint::read_msg(pbuf);
 
     if (_change_baud_timeout != nullptr && ret == ReadOk) {
         log_info("%s [%d]%s: Baudrate %u responded, keeping it", _type.c_str(), fd, _name.c_str(),

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -154,7 +154,7 @@ protected:
     virtual int read_msg(struct buffer *pbuf);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry) const;
-    void _add_sys_comp_id(uint16_t sys_comp_id);
+    void _add_sys_comp_id(uint8_t sysid, uint8_t compid);
 
     const std::string _type; ///< UART, UDP, TCP, Log
     std::string _name;       ///< Endpoint name from config file

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -151,8 +151,7 @@ public:
     struct buffer tx_buf;
 
 protected:
-    virtual int read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                         uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id);
+    virtual int read_msg(struct buffer *pbuf);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry) const;
     void _add_sys_comp_id(uint16_t sys_comp_id);
@@ -205,8 +204,7 @@ protected:
     int set_flow_control(bool enabled);
     int add_speeds(const std::vector<speed_t> &bauds);
 
-    int read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid, uint8_t *src_sysid,
-                 uint8_t *src_compid, uint32_t *msg_id) override;
+    int read_msg(struct buffer *pbuf) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
 private:

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -141,8 +141,7 @@ public:
         return has_sys_comp_id(sys_comp_id);
     }
 
-    AcceptState accept_msg(int target_sysid, int target_compid, uint8_t src_sysid,
-                           uint8_t src_compid, uint32_t msg_id) const;
+    AcceptState accept_msg(const struct buffer *pbuf) const;
 
     void filter_add_allowed_msg_id(uint32_t msg_id) { _allowed_msg_ids.push_back(msg_id); }
 

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -61,7 +61,7 @@ LogEndpoint::LogEndpoint(std::string name, LogOptions conf)
     , _config{conf}
 {
     assert(!_config.logs_dir.empty());
-    _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID << 8);
+    _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID, 0);
     _fsync_cb.aio_fildes = -1;
 
 #if HAVE_DECL_AIO_INIT

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -75,12 +75,19 @@ LogEndpoint::LogEndpoint(std::string name, LogOptions conf)
 
 void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
 {
-    uint8_t data[MAVLINK_MAX_PACKET_LEN];
-    struct buffer buffer {
-        0, data
-    };
+    uint8_t data[MAVLINK_MAX_PACKET_LEN] = {};
+    struct buffer buffer = {};
 
+    buffer.data = data;
     buffer.len = mavlink_msg_to_send_buffer(data, msg);
+    buffer.curr.msg_id = msg->msgid;
+    buffer.curr.target_sysid = target_sysid;
+    buffer.curr.target_compid = MAV_COMP_ID_ALL;
+    buffer.curr.src_sysid = msg->sysid;
+    buffer.curr.src_compid = msg->compid;
+    /* don't bother with it as it's only used by Log backends */
+    buffer.curr.payload_len = 0;
+
     Mainloop::get_instance().route_msg(&buffer, target_sysid, MAV_COMP_ID_ALL, msg->sysid,
                                        msg->compid);
 

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -88,8 +88,7 @@ void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
     /* don't bother with it as it's only used by Log backends */
     buffer.curr.payload_len = 0;
 
-    Mainloop::get_instance().route_msg(&buffer, target_sysid, MAV_COMP_ID_ALL, msg->sysid,
-                                       msg->compid);
+    Mainloop::get_instance().route_msg(&buffer);
 
     _stat.read.total++;
     _stat.read.handled++;

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -89,8 +89,7 @@ protected:
 
     bool _fsync();
 
-    void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
-                                 uint8_t source_component_id, const uint8_t *payload);
+    void _handle_auto_start_stop(const struct buffer *pbuf);
 
 private:
     int _get_file(const char *extension);

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -150,8 +150,7 @@ int Mainloop::write_msg(const std::shared_ptr<Endpoint> &e, const struct buffer 
     return r;
 }
 
-void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                         int sender_compid, uint32_t msg_id)
+void Mainloop::route_msg(struct buffer *buf)
 {
     bool unknown = true;
 
@@ -160,16 +159,18 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 
         switch (acceptState) {
         case Endpoint::AcceptState::Accepted:
-            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->fd, msg_id,
-                      target_sysid, target_compid, sender_sysid, sender_compid);
+            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->fd,
+                      buf->curr.msg_id, buf->curr.target_sysid, buf->curr.target_compid,
+                      buf->curr.src_sysid, buf->curr.src_compid);
             if (write_msg(e, buf) == -EPIPE) { // only TCP endpoints should return -EPIPE
                 should_process_tcp_hangups = true;
             }
             unknown = false;
             break;
         case Endpoint::AcceptState::Filtered:
-            log_debug("Endpoint [%d] filtered out message %u to %d/%d from %u/%u", e->fd, msg_id,
-                      target_sysid, target_compid, sender_sysid, sender_compid);
+            log_debug("Endpoint [%d] filtered out message %u to %d/%d from %u/%u", e->fd,
+                      buf->curr.msg_id, buf->curr.target_sysid, buf->curr.target_compid,
+                      buf->curr.src_sysid, buf->curr.src_compid);
             unknown = false;
             break;
         case Endpoint::AcceptState::Rejected:
@@ -181,7 +182,8 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 
     if (unknown) {
         _errors_aggregate.msg_to_unknown++;
-        log_debug("Message %u to unknown sysid/compid: %u/%u", msg_id, target_sysid, target_compid);
+        log_debug("Message %u to unknown sysid/compid: %u/%u", buf->curr.msg_id,
+                  buf->curr.target_sysid, buf->curr.target_compid);
     }
 }
 

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -156,8 +156,8 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
     bool unknown = true;
 
     for (const auto &e : this->g_endpoints) {
-        auto acceptState
-            = e->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id);
+        auto acceptState = e->accept_msg(buf);
+
         switch (acceptState) {
         case Endpoint::AcceptState::Accepted:
             log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->fd, msg_id,

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -54,8 +54,7 @@ public:
     int mod_fd(int fd, void *data, int events) const;
     int remove_fd(int fd) const;
     int loop();
-    void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                   int sender_compid, uint32_t msg_id = UINT32_MAX);
+    void route_msg(struct buffer *buf);
     void handle_tcp_connection();
     int write_msg(const std::shared_ptr<Endpoint> &e, const struct buffer *buf) const;
     void process_tcp_hangups();

--- a/src/ulog.cpp
+++ b/src/ulog.cpp
@@ -103,49 +103,30 @@ void ULog::stop()
 int ULog::write_msg(const struct buffer *buffer)
 {
     const bool mavlink2 = buffer->data[0] == MAVLINK_STX;
-    uint32_t msg_id;
-    uint8_t *payload;
-    uint16_t payload_len;
     uint8_t trimmed_zeros;
-    uint8_t source_system_id;
-    uint8_t source_component_id;
-
-    if (mavlink2) {
-        auto *msg = (struct mavlink_router_mavlink2_header *)buffer->data;
-        msg_id = msg->msgid;
-        payload = buffer->data + sizeof(struct mavlink_router_mavlink2_header);
-        payload_len = msg->payload_len;
-        source_system_id = msg->sysid;
-        source_component_id = msg->compid;
-    } else {
-        auto *msg = (struct mavlink_router_mavlink1_header *)buffer->data;
-        msg_id = msg->msgid;
-        payload = buffer->data + sizeof(struct mavlink_router_mavlink1_header);
-        payload_len = msg->payload_len;
-        source_system_id = msg->sysid;
-        source_component_id = msg->compid;
-    }
 
     /* set the expected system id to the first autopilot that we get a heartbeat from */
-    if (_target_system_id == -1 && msg_id == MAVLINK_MSG_ID_HEARTBEAT
-        && source_component_id == MAV_COMP_ID_AUTOPILOT1) {
-        _target_system_id = source_system_id;
+    if (_target_system_id == -1 && buffer->curr.msg_id == MAVLINK_MSG_ID_HEARTBEAT
+        && buffer->curr.src_compid == MAV_COMP_ID_AUTOPILOT1) {
+        _target_system_id = buffer->curr.src_sysid;
     }
 
     /* Check if we should start or stop logging */
     _handle_auto_start_stop(buffer);
 
     /* Check if we are interested in this msg_id */
-    if (msg_id != MAVLINK_MSG_ID_COMMAND_ACK && msg_id != MAVLINK_MSG_ID_LOGGING_DATA_ACKED
-        && msg_id != MAVLINK_MSG_ID_LOGGING_DATA) {
+    if (buffer->curr.msg_id != MAVLINK_MSG_ID_COMMAND_ACK
+        && buffer->curr.msg_id != MAVLINK_MSG_ID_LOGGING_DATA_ACKED
+        && buffer->curr.msg_id != MAVLINK_MSG_ID_LOGGING_DATA) {
         return buffer->len;
     }
 
-    const mavlink_msg_entry_t *msg_entry = mavlink_get_msg_entry(msg_id);
+    const mavlink_msg_entry_t *msg_entry = mavlink_get_msg_entry(buffer->curr.msg_id);
     if (!msg_entry) {
         return buffer->len;
     }
 
+    uint16_t payload_len = buffer->curr.payload_len;
     if (payload_len > msg_entry->max_msg_len) {
         payload_len = msg_entry->max_msg_len;
     }
@@ -157,11 +138,11 @@ int ULog::write_msg(const struct buffer *buffer)
     }
 
     /* Handle messages */
-    switch (msg_id) {
+    switch (buffer->curr.msg_id) {
     case MAVLINK_MSG_ID_COMMAND_ACK: {
         mavlink_command_ack_t cmd;
 
-        memcpy(&cmd, payload, payload_len);
+        memcpy(&cmd, buffer->curr.payload, payload_len);
         if (trimmed_zeros) {
             memset(((uint8_t *)&cmd) + payload_len, 0, trimmed_zeros);
         }
@@ -182,7 +163,7 @@ int ULog::write_msg(const struct buffer *buffer)
         break;
     }
     case MAVLINK_MSG_ID_LOGGING_DATA_ACKED: {
-        auto *ulog_data_acked = (mavlink_logging_data_acked_t *)payload;
+        auto *ulog_data_acked = (mavlink_logging_data_acked_t *)buffer->curr.payload;
         mavlink_message_t msg;
         mavlink_logging_ack_t ack;
 
@@ -197,11 +178,11 @@ int ULog::write_msg(const struct buffer *buffer)
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {
             mavlink_logging_data_t ulog_data;
-            memcpy(&ulog_data, payload, payload_len);
+            memcpy(&ulog_data, buffer->curr.payload, payload_len);
             memset(((uint8_t *)&ulog_data) + payload_len, 0, trimmed_zeros);
             _logging_data_process(&ulog_data);
         } else {
-            auto *ulog_data = (mavlink_logging_data_t *)payload;
+            auto *ulog_data = (mavlink_logging_data_t *)buffer->curr.payload;
             _logging_data_process(ulog_data);
         }
         break;

--- a/src/ulog.cpp
+++ b/src/ulog.cpp
@@ -133,7 +133,7 @@ int ULog::write_msg(const struct buffer *buffer)
     }
 
     /* Check if we should start or stop logging */
-    _handle_auto_start_stop(msg_id, source_system_id, source_component_id, payload);
+    _handle_auto_start_stop(buffer);
 
     /* Check if we are interested in this msg_id */
     if (msg_id != MAVLINK_MSG_ID_COMMAND_ACK && msg_id != MAVLINK_MSG_ID_LOGGING_DATA_ACKED


### PR DESCRIPTION
The parsing of mavlink header was intended to be contained in a single function, when we are reading the message from the associated buffer. Due to the addition of logging a long time ago and continuous use of the header fields to properly route the packets to the appropriate endpoint we ended up adding the same parsing to the log endpoints, including the check for different struct on mavlink1 vs mavlink2 wire format.

This is a cleanup aiming to stop doing that and rather just adding the appropriate fields in `struct buffer`. This also makes it much closer to be able to implement #39 since now we keep the msgid and could check for it against a set of msg ids in the correspondent `accept_msg()`.

This still needs to go through proper test and bench test, but apparently it's working (hey, it passes the testsuite).