### PR TITLE
Implemented proper stopping of ulog streaming

### DIFF
--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -43,6 +43,7 @@ protected:
     // These functions should never be called
     const char *_get_logfile_extension() override { return ""; };
     bool _start_timeout() override { return true; };
+    bool _stop_timeout() override { return true; };
 
 private:
     std::unique_ptr<LogEndpoint> _logger;

--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -39,6 +39,14 @@ bool BinLog::_start_timeout()
     return true;
 }
 
+bool BinLog::_stop_timeout()
+{
+    // TODO: Stop timeout not implemented for binlog, see example in ulog
+    _remove_stop_timeout();
+
+    return true;
+}
+
 bool BinLog::start()
 {
     if (!LogEndpoint::start()) {

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -40,6 +40,7 @@ public:
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
+    bool _stop_timeout() override;
 
     const char *_get_logfile_extension() override { return "bin"; };
 private:

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -48,6 +48,8 @@ public:
     virtual bool start();
     virtual void stop();
 
+    bool has_active_stop_timeout() { return _logging_stop_timeout != nullptr; }
+
 protected:
     const char *_logs_dir;
     int _target_system_id = -1;
@@ -55,6 +57,7 @@ protected:
     LogMode _mode;
 
     Timeout *_logging_start_timeout = nullptr;
+    Timeout *_logging_stop_timeout = nullptr;
     Timeout *_alive_check_timeout = nullptr;
     uint32_t _timeout_write_total = 0;
 
@@ -62,9 +65,11 @@ protected:
 
     void _send_msg(const mavlink_message_t *msg, int target_sysid);
     void _remove_start_timeout();
+    void _remove_stop_timeout();
     bool _start_alive_timeout();
 
     virtual bool _start_timeout() = 0;
+    virtual bool _stop_timeout() = 0;
     virtual bool _alive_timeout();
 
     void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -30,6 +30,10 @@
 
 #include "autolog.h"
 
+#define TIMEOUT_LOG_SHUTDOWN_US \
+    5000000ULL // number of microseconds we wait until we give up trying to stop log streaming
+               // after a shutdown of mavlink router was requested
+
 static volatile bool should_exit = false;
 
 Mainloop Mainloop::_instance{};
@@ -261,7 +265,11 @@ void Mainloop::loop()
     add_timeout(LOG_AGGREGATE_INTERVAL_SEC * MSEC_PER_SEC,
                 std::bind(&Mainloop::_log_aggregate_timeout, this, std::placeholders::_1), this);
 
-    while (!should_exit) {
+    usec_t timestamp_stop_requested = 0;
+
+    bool run_loop = true;
+
+    while (run_loop) {
         int i;
 
         r = epoll_wait(epollfd, events, max_events, -1);
@@ -294,6 +302,26 @@ void Mainloop::loop()
                 // make poll errors fatal so that an external component can
                 // restart mavlink-router
                 should_exit = true;
+            }
+
+            // we should exit the router, make sure to stop the logendpoint properly (e.g. wait for
+            // ACK) we will try for max TIMEOUT_LOG_SHUTDOWN_US to shut down the log stream before
+            // we give up and exit anyways
+            if (should_exit) {
+                if (!_log_endpoint) {
+                    // no log streaming active, exit
+                    run_loop = false;
+                } else if (_log_endpoint && timestamp_stop_requested == 0) {
+                    // log streaming is active, start timing
+                    timestamp_stop_requested = now_usec();
+                    _log_endpoint->stop();
+                } else if (_log_endpoint
+                           && (!_log_endpoint->has_active_stop_timeout()
+                               || (now_usec() - timestamp_stop_requested)
+                                   > TIMEOUT_LOG_SHUTDOWN_US)) {
+                    // log stream was either shut down successfully or we ran into timeout, exit
+                    run_loop = false;
+                }
             }
         }
 

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -42,10 +42,24 @@ struct _packed_ ulog_msg_header {
 bool ULog::_start_timeout()
 {
     mavlink_message_t msg;
-    mavlink_command_long_t cmd;
+    mavlink_command_long_t cmd {};
 
-    bzero(&cmd, sizeof(cmd));
     cmd.command = MAV_CMD_LOGGING_START;
+    cmd.target_component = MAV_COMP_ID_ALL;
+    cmd.target_system = _target_system_id;
+
+    mavlink_msg_command_long_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &cmd);
+    _send_msg(&msg, _target_system_id);
+
+    return true;
+}
+
+bool ULog::_stop_timeout()
+{
+    mavlink_message_t msg;
+    mavlink_command_long_t cmd {};
+
+    cmd.command = MAV_CMD_LOGGING_STOP;
     cmd.target_component = MAV_COMP_ID_ALL;
     cmd.target_system = _target_system_id;
 
@@ -73,21 +87,10 @@ bool ULog::start()
 
 void ULog::stop()
 {
-    mavlink_message_t msg;
-    mavlink_command_long_t cmd;
-
     if (_file == -1) {
         log_info("ULog not started");
         return;
     }
-
-    bzero(&cmd, sizeof(cmd));
-    cmd.command = MAV_CMD_LOGGING_STOP;
-    cmd.target_component = MAV_COMP_ID_ALL;
-    cmd.target_system = _target_system_id;
-
-    mavlink_msg_command_long_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &cmd);
-    _send_msg(&msg, _target_system_id);
 
     _buffer_len = 0;
     /* Write the last partial message to avoid corrupt the end of the file */
@@ -167,17 +170,26 @@ int ULog::write_msg(const struct buffer *buffer)
         if (trimmed_zeros)
             memset(((uint8_t *)&cmd) + payload_len, 0, trimmed_zeros);
 
-        if (!_logging_start_timeout || cmd.command != MAV_CMD_LOGGING_START)
+        if ((!_logging_start_timeout || cmd.command != MAV_CMD_LOGGING_START)
+            && (!_logging_stop_timeout || cmd.command != MAV_CMD_LOGGING_STOP))
             return buffer->len;
 
         if (cmd.result == MAV_RESULT_ACCEPTED) {
-            _remove_start_timeout();
-            if (!_start_alive_timeout()) {
-                log_warning("Could not start liveness timeout - mavlink router log won't be able "
-                            "to detect if flight stack stopped");
+            if (_logging_start_timeout && cmd.command == MAV_CMD_LOGGING_START) {
+                _remove_start_timeout();
+
+                if (!_start_alive_timeout()) {
+                    log_warning(
+                        "Could not start liveness timeout - mavlink router log won't be able "
+                        "to detect if flight stack stopped");
+                }
+            } else if (_logging_stop_timeout && cmd.command == MAV_CMD_LOGGING_STOP) {
+                _remove_stop_timeout();
             }
+
         } else
-            log_error("MAV_CMD_LOGGING_START result(%u) is different than accepted", cmd.result);
+            log_error("MAV_CMD_LOGGING_%s result(%u) is different than accepted",
+                      cmd.command == MAV_CMD_LOGGING_START ? "START" : "STOP", cmd.result);
         break;
     }
     case MAVLINK_MSG_ID_LOGGING_DATA_ACKED: {

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -37,6 +37,7 @@ public:
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
+    bool _stop_timeout() override;
 
     const char *_get_logfile_extension() override { return "ulg"; };
 private:


### PR DESCRIPTION
Implemented stop timeout for ulog streaming. Previously it could happen that the message for stopping ulog streaming got lost and therefore the autopilot never stopped streaming the log file.
The next time the mavlink router requested ulog streaming it was already running and thus needed to be restarted due to the missing ulog header. This caused several empty log files to be created.

With these changes the mavlink router waits for the autopilot ACK before considering the stream to be stopped. In case the router is shut down with ulog streaming still running it will try to stop the stream for 5 seconds, if unsuccessful after that it will shut down regardless of the stream still running.