### PR TITLE
adding logging heartbeat option to mavlink-router

### DIFF
--- a/src/mavlink-router/autolog.cpp
+++ b/src/mavlink-router/autolog.cpp
@@ -65,9 +65,9 @@ int AutoLog::write_msg(const struct buffer *buffer)
     /* We check autopilot on heartbeat */
     log_debug("Got autopilot %u from heartbeat", heartbeat->autopilot);
     if (heartbeat->autopilot == MAV_AUTOPILOT_PX4) {
-        _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode));
+        _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode,  _broadcast_hb));
     } else if (heartbeat->autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir, _mode));
+        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir, _mode,  _broadcast_hb));
     } else {
         log_warning("Unidentified autopilot, cannot start flight stack logging");
     }

--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -25,9 +25,10 @@
 class AutoLog : public LogEndpoint {
 public:
 
-    AutoLog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"AutoLog", logs_dir, mode}
+    AutoLog(const char *logs_dir, LogMode mode, bool heartbeat)
+        : LogEndpoint{"AutoLog", logs_dir, mode, heartbeat }
     {
+        _broadcast_hb = heartbeat;
     }
 
     int write_msg(const struct buffer *pbuf) override;
@@ -36,9 +37,11 @@ public:
     bool start() override;
     void stop() override;
     void print_statistics() override;
+    void _start_heartbeat() override { }
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; }
+    bool _broadcast_hb;
 
     // These functions should never be called
     const char *_get_logfile_extension() override { return ""; };

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -24,8 +24,8 @@
 
 class BinLog : public LogEndpoint {
 public:
-    BinLog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"BinLog", logs_dir, mode}
+    BinLog(const char *logs_dir, LogMode mode, bool heartbeat)
+        : LogEndpoint{"BinLog", logs_dir, mode, heartbeat }
     {
     }
 

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -36,13 +36,17 @@ enum class LogMode {
 
 class LogEndpoint : public Endpoint {
 public:
-    LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
+    LogEndpoint(const char *name, const char *logs_dir, LogMode mode, bool heartbeat)
         : Endpoint{name, false}
         , _logs_dir{logs_dir}
         , _mode(mode)
     {
         assert(_logs_dir);
         _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID << 8);
+
+        if (heartbeat) {
+            _start_heartbeat();
+        }
     }
 
     virtual bool start();
@@ -57,6 +61,12 @@ protected:
     Timeout *_logging_start_timeout = nullptr;
     Timeout *_alive_check_timeout = nullptr;
     uint32_t _timeout_write_total = 0;
+
+    /* heartbeat components */
+    uint8_t _system_status = MAV_STATE_STANDBY;
+    virtual void _start_heartbeat();
+    Timeout * _heartbeat_timer = nullptr;
+    bool _broadcast_log_heartbeat();
 
     virtual const char *_get_logfile_extension() = 0;
 

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -28,6 +28,8 @@
 #include <common/dbg.h>
 #include <common/log.h>
 #include <common/util.h>
+#include <src/common/log.h>
+#include <src/common/util.h>
 
 #include "comm.h"
 #include "endpoint.h"
@@ -48,7 +50,8 @@ static struct options opt = {
         .logs_dir = nullptr,
         .log_mode = LogMode::always,
         .debug_log_level = (int)Log::Level::INFO,
-        .mavlink_dialect = Auto
+        .mavlink_dialect = Auto,
+        .heartbeat = false
 };
 
 static const struct option long_options[] = {
@@ -60,12 +63,13 @@ static const struct option long_options[] = {
     { "tcp-endpoint",           required_argument,  NULL,   'p' },
     { "log",                    required_argument,  NULL,   'l' },
     { "debug-log-level",        required_argument,  NULL,   'g' },
+    { "heartbeat"      ,        no_argument,        NULL,   'b' },
     { "verbose",                no_argument,        NULL,   'v' },
     { "version",                no_argument,        NULL,   'V' },
     { }
 };
 
-static const char* short_options = "he:rt:c:d:l:p:g:vV";
+static const char* short_options = "he:rt:c:d:l:p:g:bvV";
 
 static void help(FILE *fp) {
     fprintf(fp,
@@ -88,6 +92,7 @@ static void help(FILE *fp) {
             "  -l --log <directory>         Enable Flight Stack logging\n"
             "  -g --debug-log-level <level> Set debug log level. Levels are\n"
             "                               <error|warning|info|debug>\n"
+            "  -b --heartbeat               Broadcast log status as heartbeat when logging is enabled\n"
             "  -v --verbose                 Verbose. Same as --debug-log-level=debug\n"
             "  -V --version                 Show version\n"
             "  -h --help                    Print this message\n"
@@ -438,6 +443,10 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
             opt.debug_log_level = lvl;
+            break;
+        }
+        case 'b': {
+            opt.heartbeat = true;
             break;
         }
         case 'v': {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -357,7 +357,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
 
     for (conf = opt->endpoints; conf; conf = conf->next) {
         if (conf->type != Tcp) {
-            // TCP endpoints are efemeral, that's why they don't
+            // TCP endpoints are ephemeral, that's why they don't
             // live on `g_endpoints` array, but on `g_tcp_endpoints` list
             n_endpoints++;
         }
@@ -443,11 +443,11 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
 
     if (opt->logs_dir) {
         if (opt->mavlink_dialect == Ardupilotmega) {
-            _log_endpoint = new BinLog(opt->logs_dir, opt->log_mode);
+            _log_endpoint = new BinLog(opt->logs_dir, opt->log_mode, opt->heartbeat);
         } else if (opt->mavlink_dialect == Common) {
-            _log_endpoint = new ULog(opt->logs_dir, opt->log_mode);
+            _log_endpoint = new ULog(opt->logs_dir, opt->log_mode, opt->heartbeat);
         } else {
-            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
+            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode, opt->heartbeat);
         }
         g_endpoints[i] = _log_endpoint;
     }

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -130,4 +130,5 @@ struct options {
     LogMode log_mode;
     int debug_log_level;
     enum mavlink_dialect mavlink_dialect;
+    bool heartbeat;
 };

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -23,8 +23,8 @@
 
 class ULog : public LogEndpoint {
 public:
-    ULog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"ULog", logs_dir, mode}
+    ULog(const char *logs_dir, LogMode mode, bool heartbeat)
+        : LogEndpoint{"ULog", logs_dir, mode, heartbeat}
     {
     }
 


### PR DESCRIPTION
This pr adds the ability for the mavlink router to broadcast a heartbeat with it's status when in logging mode. It can be used to make sure the on board companion computer logger is up and running before arming a vehicle.

Here is fmu output under normal operation (notice the transition of 155 an on board logger from status 3 to 4):

Got onboard heartbeat 155, 3
Got onboard heartbeat 155, 3
Got onboard heartbeat 155, 3
INFO [logger] Start file log (type: full)
INFO [logger] Opened full log file: /fs/microsd/log/2019-05-15/23_08_17.ulg
Got onboard heartbeat 155, 4
INFO [logger] Start mavlink log
Got onboard heartbeat 155, 4
Got onboard heartbeat 155, 4
Got onboard heartbeat 155, 4
Got onboard heartbeat 155, 4
Got onboard heartbeat 155, 4
Got onboard heartbeat 155, 4
INFO [logger] Stop mavlink log
Got onboard heartbeat 155, 3
INFO [logger] closed logfile, bytes written: 239363
Got onboard heartbeat 155, 3
Got onboard heartbeat 155, 3

Here is what happens when the logger fails to open a new log file (no transition):

Got onboard heartbeat 155, 3
Got onboard heartbeat 155, 3
INFO [logger] Start file log (type: full)
INFO [logger] Opened full log file: /fs/microsd/log/2019-05-15/23_05_37.ulg
Got onboard heartbeat 155, 3
Got onboard heartbeat 155, 3
Got onboard heartbeat 155, 3

Tested on a pocket beagle and laptop with a Pixhawk Cube running px4.