### PR TITLE
Travis CI: Lint Python code for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
             - python3-setuptools
 
 before_script:
-        - pip3 install --user future pymavlink
+        - pip3 install --user flake8 future pymavlink
+        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         - CXX="g++-6"
         - CC="gcc-6"
 


### PR DESCRIPTION
15 files with Python syntax errors https://travis-ci.org/intel/mavlink-router/builds/587837498#L334