### PR TITLE
Add a fixed mode to UdpEndpoint

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -78,13 +78,14 @@
 #       route messages to (and from). If on `Eavesdropping` mode,
 #       IP of interface to which mavlink-router will listen for
 #       incoming packets. In this case, `0.0.0.0` means that
-#       mavlink-router will listen on all interfaces.
+#       mavlink-router will listen on all interfaces. If on
+#       `Multicast` mode, same as `Eavesdropping`.
 #       IPv6 addresses must be enclosed in square brackets.
 #       No default value. Must be defined.
 #
 #   Mode
-#       One of <normal> or <eavesdropping>. See `Address` for more
-#       information.
+#       One of <normal>, <eavesdropping> or <multicast>. See `Address`
+#       (and `TargetAddress`) for more information.
 #       No default value. Must be defined
 #
 #   Port
@@ -92,6 +93,16 @@
 #       packets (or listen for them).
 #       Default value: Increasing value, starting from 14550, when
 #       mode is `Normal`. Must be defined if on `Eavesdropping` mode.
+#
+#   TargetAddress
+#       Only needed in `Multicast` mode.
+#       IP address where messages should be sent to. This can either be a
+#       unicast address or a broadcast address or multicast group. In case
+#       of a multicast address, the receiving interface will only listen
+#       to that multicast group.
+#       Using a link-local IPv6 address or multicast group here requires
+#       the Address field to be the an interface's local address! So
+#       listening on all interfaces is not supported in that case.
 #
 # Section [TcpEndpoint]: This section must have a name
 #

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -776,6 +776,11 @@ int UdpEndpoint::open(const char *ip, unsigned long port, UdpEndpoint::UdpMode m
         char *ip_str = strdup(&ip[1]);
         ip_str[strlen(ip_str) - 1] = '\0';
 
+        /* remove omittable zeros from IPv6 address */
+        sockaddr_in6 ip_addr;
+        inet_pton(AF_INET6, ip_str, &ip_addr.sin6_addr);
+        inet_ntop(AF_INET6, &(ip_addr.sin6_addr), ip_str, strlen(ip));
+
         /* do some more input validation for multicast mode */
         if (_mode == UdpEndpoint::UdpMode::Multicast) {
             if (nullptr == target_ip) {

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -448,8 +448,8 @@ bool Endpoint::is_ipv6(const char *ip)
 
 bool Endpoint::ipv6_is_linklocal(const char *ip)
 {
-    /* link-local addresses start with fe80 */
-    if (strncmp(ip, "fe80", 4) == 0) {
+    /* link-local addresses start with fe80, ULA addresses are in fc::/7 range */
+    if (strncmp(ip, "fe80", 4) == 0 || strncmp(ip, "fc", 2) == 0 || strncmp(ip, "fd", 2) == 0) {
         return true;
     }
     return false;

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -110,6 +110,7 @@ protected:
     bool _check_crc(const mavlink_msg_entry_t *msg_entry);
     void _add_sys_comp_id(uint16_t sys_comp_id);
 
+    static bool ipv4_is_multicast(const char *ip);
 #ifdef ENABLE_IPV6
     static bool is_ipv6(const char *ip);
     static bool ipv6_is_linklocal(const char *ip);
@@ -186,11 +187,13 @@ public:
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
-    int open(const char *ip, unsigned long port, UdpMode mode = UdpEndpoint::Normal);
+    int open(const char *ip, unsigned long port, UdpMode mode = UdpEndpoint::Normal, const char *target_ip = nullptr);
 
     struct sockaddr_in sockaddr;
+    struct sockaddr_in sockaddr_out;
 #ifdef ENABLE_IPV6
     struct sockaddr_in6 sockaddr6;
+    struct sockaddr_in6 sockaddr6_out;
     bool is_ipv6;
 #endif
 

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -174,13 +174,19 @@ private:
 
 class UdpEndpoint : public Endpoint {
 public:
+    enum UdpMode {
+        Normal,        // Sending mode
+        Eavesdropping, // Listening mode
+        Multicast      // Listending and sending multicast/ broadcast
+    };
+
     UdpEndpoint();
     virtual ~UdpEndpoint() { }
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
-    int open(const char *ip, unsigned long port, bool bind = false);
+    int open(const char *ip, unsigned long port, UdpMode mode = UdpEndpoint::Normal);
 
     struct sockaddr_in sockaddr;
 #ifdef ENABLE_IPV6
@@ -190,6 +196,8 @@ public:
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
+
+    UdpEndpoint::UdpMode _mode;
 };
 
 class TcpEndpoint : public Endpoint {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -404,7 +404,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         }
         case Udp: {
             std::unique_ptr<UdpEndpoint> udp{new UdpEndpoint{}};
-            if (udp->open(conf->address, conf->port, conf->eavesdropping) < 0) {
+            if (udp->open(conf->address, conf->port, conf->mode) < 0) {
                 log_error("Could not open %s:%ld", conf->address, conf->port);
                 return false;
             }

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -114,7 +114,7 @@ struct endpoint_config {
             char *address;
             long unsigned port;
             int retry_timeout;
-            bool eavesdropping;
+            UdpEndpoint::UdpMode mode;
         };
         struct {
             char *device;

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -36,7 +36,7 @@ public:
     int remove_fd(int fd);
     void loop();
     void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                   int sender_compid, uint32_t msg_id = UINT32_MAX);
+                   int sender_compid, uint32_t msg_id = UINT32_MAX, Endpoint *sender = nullptr);
     void handle_read(Endpoint *e);
     void handle_canwrite(Endpoint *e);
     void handle_tcp_connection();
@@ -115,6 +115,7 @@ struct endpoint_config {
             long unsigned port;
             int retry_timeout;
             UdpEndpoint::UdpMode mode;
+            char *targetAddress;
         };
         struct {
             char *device;


### PR DESCRIPTION
For Drone-to-Drone cooperative awareness a bi-directional broadcast (or IPv6 multicast) communication is needed, e.g. for the [UTM_GLOBAL_POSITION](https://mavlink.io/en/messages/common.html#UTM_GLOBAL_POSITION) message. The current modes (eavesdropping and normal) are not suitable, because we want to receive packets (which could be done with eavesdropping), but also already send messages before another party has "connected".

This pull-request adds another mode to the UdpEndpoint, where a binding and a target address can be set. If the target address is an IPv6 multicast group, packets addressed to this group will be captured (as well as unicast packets) and outgoing messages will be sent to this group. The binding address is needed to make sure, that outgoing packets are sent through the right interface. IPv4 broadcast also works fine, multicast would need a manual step to add the multicast address to the network interface for receiving packets. A unicast link is also possible.

To make this work, the routing of MAVLink messages had to be adapted. Previously incoming packets were presented to all endpoints, even the one where the message has been received from. This worked, because mavlink-router kept track of the connected systemIDs and used them for loop prevention. With UTM messages, which are all addressed to the MAVLink broadcast systemID, this is not possible any more. Therefore the routing was changes to just present incoming messages to all endpoints besides the one, which received the message in the first place.

Since #225 was merged, please let me know, if I should rebase this branch before merging. Sorry for opening this PR so late, currently I'm busy preparing a demo based on this. At least it's already bench-tested now, and will be flight-tested in the next few weeks.
Some code was inspired by #174 and this PR might also solve that issue.