### PR TITLE
Add possibility to filter by source component ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Message filters:
 
   - AllowMsgIdOut: If set, only allow messages with the listed message IDs to
     be sent via this endpoint
+  - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
+    compoent IDs to be sent via this endpoint
 
 ### Flight Stack Logging
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -99,6 +99,12 @@
 # Default: Empty list (disabled)
 #AllowMsgIdOut = 
 
+# Only allow messages from the specified MAVLink source component IDs to be
+# sent via this endpoint. An empty list allows all source components.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#AllowSrcCompOut = 
+
 ## Example
 [UartEndpoint alpha]
 Device = /dev/ttyS0

--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -542,6 +542,30 @@ int ConfFile::parse_uint8_vector(const char *val, size_t val_len, void *storage,
     return 0;
 }
 
+int ConfFile::parse_uint32_vector(const char *val, size_t val_len, void *storage,
+                                  size_t storage_len)
+{
+    assert(val);
+    assert(storage);
+    assert(val_len);
+
+    std::vector<uint32_t> *target;
+    if (storage_len < sizeof(*target)) {
+        return -ENOBUFS;
+    }
+
+    char *filter_string = strndupa(val, val_len);
+    target = static_cast<std::vector<uint32_t> *>(storage);
+
+    char *token = strtok(filter_string, ",");
+    while (token != nullptr) {
+        target->push_back(atol(token)); // we need 32 bit unsigned int, but atoi is signed
+        token = strtok(nullptr, ",");
+    }
+
+    return 0;
+}
+
 int ConfFile::parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
     int ival, ret;

--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -504,17 +504,18 @@ int ConfFile::parse_str_buf(const char *val, size_t val_len, void *storage, size
 
 int ConfFile::parse_stdstring(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
-    auto *ptr = (std::string *)storage;
-
     assert(val);
     assert(storage);
     assert(val_len);
 
-    if (storage_len < sizeof(char *)) {
+    std::string *target;
+    if (storage_len < sizeof(*target)) {
         return -ENOBUFS;
     }
 
-    ptr->assign(val, val_len);
+    target = static_cast<std::string *>(storage);
+
+    target->assign(val, val_len);
     return 0;
 }
 
@@ -524,12 +525,13 @@ int ConfFile::parse_uint8_vector(const char *val, size_t val_len, void *storage,
     assert(storage);
     assert(val_len);
 
-    if (storage_len < sizeof(bool)) {
+    std::vector<uint8_t> *target;
+    if (storage_len < sizeof(*target)) {
         return -ENOBUFS;
     }
 
     char *filter_string = strndupa(val, val_len);
-    auto *target = (std::vector<uint8_t> *)storage;
+    target = static_cast<std::vector<uint8_t> *>(storage);
 
     char *token = strtok(filter_string, ",");
     while (token != nullptr) {
@@ -542,27 +544,29 @@ int ConfFile::parse_uint8_vector(const char *val, size_t val_len, void *storage,
 
 int ConfFile::parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
-    bool *b = (bool *)storage;
     int ival, ret;
 
     assert(val);
     assert(storage);
     assert(val_len);
 
-    if (storage_len < sizeof(bool)) {
+    bool *target;
+    if (storage_len < sizeof(*target)) {
         return -ENOBUFS;
     }
 
+    target = static_cast<bool *>(storage);
+
     if (memcaseeq("true", 4, val, val_len)) {
-        *b = true;
+        *target = true;
     } else if (memcaseeq("false", 5, val, val_len)) {
-        *b = false;
+        *target = false;
     } else {
         ret = parse_i(val, val_len, &ival, sizeof(ival));
         if (ret < 0) {
             return ret;
         }
-        *b = !!ival;
+        *target = !!ival;
     }
 
     return 0;

--- a/src/common/conf_file.h
+++ b/src/common/conf_file.h
@@ -125,6 +125,8 @@ public:
     static int parse_stdstring(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_uint8_vector(const char *val, size_t val_len, void *storage,
                                   size_t storage_len);
+    static int parse_uint32_vector(const char *val, size_t val_len, void *storage,
+                                   size_t storage_len);
 
 #define DECLARE_PARSE_INT(_type) \
     static int parse_##_type(const char *val, size_t val_len, void *storage, size_t storage_len)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -58,7 +58,7 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"baud",            false, UartEndpoint::parse_baudrates,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, baudrates)},
     {"device",          true,  ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, device)},
     {"FlowControl",     false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
-    {"AllowMsgIdOut",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
+    {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
 };
 
 const char *UdpEndpoint::section_pattern = "udpendpoint *";
@@ -66,8 +66,8 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
-    {"filter",          false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
-    {"AllowMsgIdOut",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
+    {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
+    {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
 };
 
 const char *TcpEndpoint::section_pattern = "tcpendpoint *";
@@ -75,7 +75,7 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
-    {"AllowMsgIdOut",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
+    {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
 };
 // clang-format on
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -41,7 +41,7 @@ struct UartEndpointConfig {
     std::string device;
     std::vector<speed_t> baudrates;
     bool flowcontrol{false};
-    std::vector<uint8_t> allow_msg_id_out;
+    std::vector<uint32_t> allow_msg_id_out;
 };
 
 struct UdpEndpointConfig {
@@ -51,7 +51,7 @@ struct UdpEndpointConfig {
     std::string address;
     unsigned long port;
     Mode mode;
-    std::vector<uint8_t> allow_msg_id_out;
+    std::vector<uint32_t> allow_msg_id_out;
 };
 
 struct TcpEndpointConfig {
@@ -59,7 +59,7 @@ struct TcpEndpointConfig {
     std::string address;
     unsigned long port;
     int retry_timeout{5};
-    std::vector<uint8_t> allow_msg_id_out;
+    std::vector<uint32_t> allow_msg_id_out;
 };
 
 /*

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -42,6 +42,7 @@ struct UartEndpointConfig {
     std::vector<speed_t> baudrates;
     bool flowcontrol{false};
     std::vector<uint32_t> allow_msg_id_out;
+    std::vector<uint8_t> allow_src_comp_out;
 };
 
 struct UdpEndpointConfig {
@@ -52,6 +53,7 @@ struct UdpEndpointConfig {
     unsigned long port;
     Mode mode;
     std::vector<uint32_t> allow_msg_id_out;
+    std::vector<uint8_t> allow_src_comp_out;
 };
 
 struct TcpEndpointConfig {
@@ -60,6 +62,7 @@ struct TcpEndpointConfig {
     unsigned long port;
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
+    std::vector<uint8_t> allow_src_comp_out;
 };
 
 /*
@@ -144,6 +147,7 @@ public:
     AcceptState accept_msg(const struct buffer *pbuf) const;
 
     void filter_add_allowed_msg_id(uint32_t msg_id) { _allowed_msg_ids.push_back(msg_id); }
+    void filter_add_allowed_src_comp(uint8_t src_comp) { _allowed_src_comps.push_back(src_comp); }
 
     std::string get_type() const { return this->_type; }
 
@@ -182,6 +186,7 @@ protected:
 
 private:
     std::vector<uint32_t> _allowed_msg_ids;
+    std::vector<uint8_t> _allowed_src_comps;
 };
 
 class UartEndpoint : public Endpoint {
@@ -194,7 +199,7 @@ public:
 
     bool setup(UartEndpointConfig config); ///< open UART device and apply config
 
-    static const ConfFile::OptionsTable option_table[4];
+    static const ConfFile::OptionsTable option_table[5];
     static const char *section_pattern;
     static int parse_baudrates(const char *val, size_t val_len, void *storage, size_t storage_len);
     static bool validate_config(const UartEndpointConfig &config);
@@ -226,7 +231,7 @@ public:
 
     bool setup(UdpEndpointConfig config); ///< open socket and apply config
 
-    static const ConfFile::OptionsTable option_table[5];
+    static const ConfFile::OptionsTable option_table[6];
     static const char *section_pattern;
     static int parse_udp_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
     static bool validate_config(const UdpEndpointConfig &config);
@@ -268,7 +273,7 @@ public:
     bool reopen();                      ///< re-try connecting to the server
     void close();
 
-    static const ConfFile::OptionsTable option_table[4];
+    static const ConfFile::OptionsTable option_table[5];
     static const char *section_pattern;
     static bool validate_config(const TcpEndpointConfig &config);
 


### PR DESCRIPTION
For a quite special use case, we'll need to filter outgoing messages by source component ID. This commit adds a corresponding config parameter to all endpoints. While implementing this feature, I also realized, that the current message ID filter is only present at the UDP endpoint. To keep everything consistent, I added the message ID filter to all endpoint types.

Our use case is the following:
Multiple telemetry receivers would be distributed on the ground and one or multiple drones fly in the coverage area. All of these receivers should forward the received messages to a central instance of mavlink-router. But transmission from the central router to the base stations should also work. All of them should send out the message, because it is not known which base station can reach the drone.
Because two or more base stations might receive messages from one drone, this will definitely lead to duplicated messages. But this is not the issue. The issue this PR should work around is, that the central mavlink-router instance would forward messages received by one base station to all other connected base stations. Therefore we want to limit the transmission to the base stations to the component ID of ground control software.

A cleaner way would be to have the possibility to group endpoints to a link with multiple failover links and prohibit routing between the endpoints in one group, and/or to enhance the known systems list with some kind of timeout, which cleans up systems from the list. But this would add way more complexity to the system with many possible side-effects.

Another use case of the component ID filtering would be to have multiple systems on the drone connected via mavlink-router but only send messages from the FMU via a (bandwidth-limited) telemetry link.