### PR TITLE
Dynamic endpoints, mainloop refactoring, coalescing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,18 +12,20 @@ on:
 
 jobs:
   ubuntu:
-    name: ubuntu (latest)
-    runs-on: ubuntu-latest
+    name: ubuntu 20.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
         with:
           submodules: recursive
       - name: install tools
-        run: sudo apt-get install -y python3-pip python3-setuptools && pip3 install future pymavlink
+        run: sudo apt-get install -y python3-pip python3-setuptools libgtest-dev && pip3 install future pymavlink
       - name: configure
         run: ./autogen.sh c --with-systemdsystemunitdir=/usr/lib/systemd/system
       - name: build
-        run: make -j
+        run: make -j`nproc --all`
+      - name: build tests
+        run: make -j`nproc --all` mainloop_test
       - name: test
         run: make check PYTHON=python3
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -147,14 +147,26 @@ mainloop_test_SOURCES = \
 	src/common/log.h \
 	src/common/util.c \
 	src/common/util.h \
+	src/common/xtermios.cpp \
+	src/common/xtermios.h \
+	src/mavlink-router/autolog.cpp \
+	src/mavlink-router/autolog.h \
+	src/mavlink-router/binlog.cpp \
+	src/mavlink-router/binlog.h \
+	src/mavlink-router/comm.h \
+	src/mavlink-router/endpoint.h \
 	src/mavlink-router/endpoint.cpp \
 	src/mavlink-router/endpoint.h \
+	src/mavlink-router/logendpoint.cpp \
+	src/mavlink-router/logendpoint.h \
 	src/mavlink-router/mainloop_test.cpp \
 	src/mavlink-router/mainloop.cpp \
 	src/mavlink-router/pollable.cpp \
 	src/mavlink-router/pollable.h \
 	src/mavlink-router/timeout.cpp \
-	src/mavlink-router/timeout.h
+	src/mavlink-router/timeout.h \
+	src/mavlink-router/ulog.h \
+	src/mavlink-router/ulog.cpp
 mainloop_test_LDADD = $(GTEST_LIBS)
 
 # ------------------------------------------------------------------------------

--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -43,6 +43,7 @@ protected:
     // These functions should never be called
     const char *_get_logfile_extension() override { return ""; };
     bool _start_timeout() override { return true; };
+    bool _stop_timeout() override { return true; };
 
 private:
     std::unique_ptr<LogEndpoint> _logger;

--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -39,6 +39,14 @@ bool BinLog::_start_timeout()
     return true;
 }
 
+bool BinLog::_stop_timeout()
+{
+    // TODO: Stop timeout not implemented for binlog, see example in ulog
+    _remove_stop_timeout();
+
+    return true;
+}
+
 bool BinLog::start()
 {
     if (!LogEndpoint::start()) {

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -41,6 +41,7 @@ public:
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
+    bool _stop_timeout() override;
 
     const char *_get_logfile_extension() override { return "bin"; };
 private:

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -329,8 +329,8 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
 
-    if (msg_id != UINT32_MAX && 
-        _message_filter.size() > 0 && 
+    if (msg_id != UINT32_MAX &&
+        _message_filter.size() > 0 &&
         std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
 
         // if filter is defined and message is not in the set then discard it

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -97,8 +97,10 @@ public:
     }
 
     bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
+    void postprocess_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
 
     void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
+    void add_message_to_nodelay(uint32_t msg_id) { _message_nodelay.push_back(msg_id); }
 
     void start_expire_timer();
 
@@ -149,6 +151,7 @@ protected:
 private:
     Timeout* _expire_timer = nullptr;
     std::vector<uint32_t> _message_filter;
+    std::vector<uint32_t> _message_nodelay;
 };
 
 class UartEndpoint : public Endpoint {
@@ -182,12 +185,14 @@ private:
 class UdpEndpoint : public Endpoint {
 public:
     UdpEndpoint();
-    virtual ~UdpEndpoint() {}
+    ~UdpEndpoint() override;
 
     int write_msg(const struct buffer *pbuf) override;
-    int flush_pending_msgs() override { return -ENOSYS; }
+    int flush_pending_msgs() override;
 
     int open(const char *ip, unsigned long port, bool bind = false);
+
+    void set_coalescing(unsigned int bytes, unsigned int milliseconds);
 
     struct sockaddr_in sockaddr;
 #ifdef ENABLE_IPV6
@@ -198,11 +203,10 @@ public:
 protected:
 
     void _schedule_write();
-    int _force_write();
     bool _write_scheduled;
 
     Timeout* _write_schedule_timer = nullptr;
-    const unsigned int _max_packet_size, _max_timeout_ms;
+    unsigned int _max_packet_size, _max_timeout_ms;
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 };

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -157,7 +157,7 @@ public:
         : Endpoint {"UART"}
     {
     }
-    virtual ~UartEndpoint();
+    ~UartEndpoint() override;
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
@@ -196,13 +196,21 @@ public:
 #endif
 
 protected:
+
+    void _schedule_write();
+    int _force_write();
+    bool _write_scheduled;
+
+    Timeout* _write_schedule_timer = nullptr;
+    const unsigned int _max_packet_size, _max_timeout_ms;
+
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 };
 
 class TcpEndpoint : public Endpoint {
 public:
     TcpEndpoint();
-    ~TcpEndpoint();
+    ~TcpEndpoint() override;
 
     int accept(int listener_fd);
     int open(const char *ip, unsigned long port);

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -100,6 +100,12 @@ public:
 
     void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
 
+    void start_expire_timer();
+
+    void reset_expire_timer();
+
+    void del_expire_timer();
+
     struct buffer rx_buf;
     struct buffer tx_buf;
 
@@ -141,6 +147,7 @@ protected:
     std::vector<uint16_t> _sys_comp_ids;
 
 private:
+    Timeout* _expire_timer = nullptr;
     std::vector<uint32_t> _message_filter;
 };
 
@@ -175,7 +182,7 @@ private:
 class UdpEndpoint : public Endpoint {
 public:
     UdpEndpoint();
-    virtual ~UdpEndpoint() { }
+    virtual ~UdpEndpoint() {}
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
@@ -212,7 +219,7 @@ public:
     int retry_timeout = 0;
 
     inline const char *get_ip() {
-        return _ip;
+        return _ip.c_str();
     }
 
     inline unsigned long get_port() {
@@ -225,7 +232,7 @@ protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
 private:
-    char *_ip = nullptr;
+    std::string _ip;
     unsigned long _port = 0;
     bool _valid = true;
 };

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -304,6 +304,11 @@ int LogEndpoint::_get_file(const char *extension)
 
 void LogEndpoint::stop()
 {
+    if (_logging_stop_timeout) {
+        // a stop was already requested
+        return;
+    }
+
     Mainloop &mainloop = Mainloop::get_instance();
     if (_logging_start_timeout) {
         mainloop.del_timeout(_logging_start_timeout);
@@ -330,10 +335,22 @@ void LogEndpoint::stop()
     if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, _filename) < (int)sizeof(log_file)) {
         chmod(log_file, S_IRUSR|S_IRGRP|S_IROTH);
     }
+
+    _logging_stop_timeout = Mainloop::get_instance().add_timeout(
+        MSEC_PER_SEC, std::bind(&LogEndpoint::_stop_timeout, this), this);
+    if (!_logging_stop_timeout) {
+        log_error("Unable to add timeout for stopping log streaming");
+    }
+
+    _stop_timeout();
 }
 
 bool LogEndpoint::start()
 {
+    if (_logging_stop_timeout) {
+        return false;
+    }
+
     if (_file != -1) {
         log_warning("Log already started");
         return false;
@@ -414,6 +431,12 @@ void LogEndpoint::_remove_start_timeout()
     _logging_start_timeout = nullptr;
 }
 
+void LogEndpoint::_remove_stop_timeout()
+{
+    Mainloop::get_instance().del_timeout(_logging_stop_timeout);
+    _logging_stop_timeout = nullptr;
+}
+
 bool LogEndpoint::_start_alive_timeout()
 {
     _alive_check_timeout = Mainloop::get_instance().add_timeout(
@@ -429,7 +452,7 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
     }
     if (_mode == LogMode::always) {
         if (_file == -1) {
-            if (!start()) _mode = LogMode::disabled;
+            if (!start() && !_logging_stop_timeout) _mode = LogMode::disabled;
         }
     } else if (_mode == LogMode::while_armed) {
         if (msg_id == MAVLINK_MSG_ID_HEARTBEAT && source_system_id == _target_system_id
@@ -438,7 +461,7 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
             const mavlink_heartbeat_t *heartbeat = (mavlink_heartbeat_t *)payload;
             const bool is_armed = heartbeat->base_mode & MAV_MODE_FLAG_SAFETY_ARMED;
 
-            if (_file == -1 && is_armed) {
+            if (_file == -1 && is_armed && !_logging_stop_timeout) {
                 if (!start()) _mode = LogMode::disabled;
             } else if (_file != -1 && !is_armed) {
                 stop();

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -43,6 +43,8 @@ public:
     virtual bool start();
     virtual void stop();
 
+    bool has_active_stop_timeout() {return _logging_stop_timeout != nullptr;}
+
     /**
      * Check existing log files and mark logs as read-only if needed.
      * This handles the case where the system (or mavlink-router) crashed or
@@ -59,6 +61,7 @@ protected:
     LogMode _mode;
 
     Timeout *_logging_start_timeout = nullptr;
+    Timeout *_logging_stop_timeout = nullptr;
     Timeout *_fsync_timeout = nullptr;
     Timeout *_alive_check_timeout = nullptr;
     uint32_t _timeout_write_total = 0;
@@ -68,9 +71,11 @@ protected:
 
     void _send_msg(const mavlink_message_t *msg, int target_sysid);
     void _remove_start_timeout();
+    void _remove_stop_timeout();
     bool _start_alive_timeout();
 
     virtual bool _start_timeout() = 0;
+    virtual bool _stop_timeout() = 0;
     virtual bool _alive_timeout();
 
     bool _fsync();

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -226,8 +226,9 @@ fail:
     return ret;
 }
 
-static int add_endpoint_address(const char *name, size_t name_len, const char *ip,
-                                long unsigned port, bool eavesdropping, const char *filter)
+static int add_udp_endpoint_address(const char *name, size_t name_len, const char *ip,
+                                    long unsigned port, bool eavesdropping, const char *filter,
+                                    int coalesce_bytes, int coalesce_ms, const char *coalesce_nodelay)
 {
     int ret;
 
@@ -276,6 +277,16 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
     }
 
     conf->eavesdropping = eavesdropping;
+    conf->coalesce_bytes = coalesce_bytes;
+    conf->coalesce_ms = coalesce_ms;
+
+    if (coalesce_nodelay) {
+        conf->coalesce_nodelay = strdup(coalesce_nodelay);
+        if (!conf->coalesce_nodelay) {
+            ret = -ENOMEM;
+            goto fail;
+        }
+    }
 
     conf->next = opt.endpoints;
     opt.endpoints = conf;
@@ -437,7 +448,7 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
 
-            add_endpoint_address(NULL, 0, ip, port, false, NULL);
+            add_udp_endpoint_address(NULL, 0, ip, port, false, NULL, 0, 0, NULL);
             free(ip);
             break;
         }
@@ -533,7 +544,7 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
 
-            add_endpoint_address(NULL, 0, base, number, true, NULL);
+            add_udp_endpoint_address(NULL, 0, base, number, true, NULL, 0, 0, NULL);
         } else {
             const char *bauds = number != ULONG_MAX ? base + strlen(base) + 1 : NULL;
             int ret = add_uart_endpoint(NULL, 0, base, bauds, false);
@@ -720,12 +731,18 @@ static int parse_confs(ConfFile &conf)
         bool eavesdropping;
         unsigned long port;
         char *filter;
+        unsigned long coalesce_bytes;
+        unsigned long coalesce_ms;
+        char *coalesce_nodelay;
     };
     static const ConfFile::OptionsTable option_table_udp[] = {
-        {"address", true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
-        {"mode",    true,   parse_mode,                 OPTIONS_TABLE_STRUCT_FIELD(option_udp, eavesdropping)},
-        {"port",    false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
-        {"filter",  false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
+        {"address",         true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
+        {"mode",            true,   parse_mode,                 OPTIONS_TABLE_STRUCT_FIELD(option_udp, eavesdropping)},
+        {"port",            false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
+        {"filter",          false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
+        {"CoalesceBytes",   false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, coalesce_bytes)},
+        {"CoalesceMs",      false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, coalesce_ms)},
+        {"CoalesceNoDelay", false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, coalesce_nodelay)},
     };
 
     struct option_tcp {
@@ -763,7 +780,7 @@ static int parse_confs(ConfFile &conf)
     pattern = "udpendpoint *";
     offset = strlen(pattern) - 1;
     while (conf.get_sections(pattern, &iter) == 0) {
-        struct option_udp opt_udp = {nullptr, false, ULONG_MAX};
+        struct option_udp opt_udp = {nullptr, false, ULONG_MAX, nullptr, 0, 0, nullptr};
         ret = conf.extract_options(&iter, option_table_udp, ARRAY_SIZE(option_table_udp), &opt_udp);
         if (ret == 0) {
             if (opt_udp.eavesdropping && opt_udp.port == ULONG_MAX) {
@@ -774,13 +791,16 @@ static int parse_confs(ConfFile &conf)
                     log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name, opt_udp.addr);
                     ret = -EINVAL;
                 } else {
-                    ret = add_endpoint_address(iter.name + offset, iter.name_len - offset, opt_udp.addr,
-                                               opt_udp.port, opt_udp.eavesdropping, opt_udp.filter);
+                    ret = add_udp_endpoint_address(iter.name + offset, iter.name_len - offset, opt_udp.addr,
+                                                   opt_udp.port, opt_udp.eavesdropping, opt_udp.filter,
+                                                   opt_udp.coalesce_bytes, opt_udp.coalesce_ms, opt_udp.coalesce_nodelay);
                 }
             }
         }
 
         free(opt_udp.addr);
+        free(opt_udp.coalesce_nodelay);
+        free(opt_udp.filter);
         if (ret < 0)
             return ret;
     }
@@ -901,10 +921,12 @@ static void free_endpoints_options_strings(struct options* opts)
         auto next = e->next;
         if (e->type == Udp || e->type == Tcp) {
             free(e->address);
+            free(e->coalesce_nodelay);
         } else {
             free(e->device);
             delete e->bauds;
         }
+        free(e->filter);
         free(e->name);
         free(e);
         e = next;

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -887,6 +887,30 @@ fail:
     return ret;
 }
 
+/*
+ * Frees dynamically allocated strings in options struct. This code was
+ * extracted from Mainloop (where it does not belong at all) and simply
+ * moved here verbatim as a "slightly" better place.
+ *
+ * XXX: it should go to proper encapsulation in config system; it should
+ * not use C memory management.
+ */
+static void free_endpoints_options_strings(struct options* opts)
+{
+    for (auto e = opts->endpoints; e;) {
+        auto next = e->next;
+        if (e->type == Udp || e->type == Tcp) {
+            free(e->address);
+        } else {
+            free(e->device);
+            delete e->bauds;
+        }
+        free(e->name);
+        free(e);
+        e = next;
+    }
+}
+
 int main(int argc, char *argv[])
 {
     Mainloop mainloop;
@@ -916,7 +940,7 @@ int main(int argc, char *argv[])
 
     mainloop.loop();
 
-    mainloop.free_endpoints(&opt);
+    free_endpoints_options_strings(&opt);
 
     free(opt.logs_dir);
 
@@ -925,7 +949,8 @@ int main(int argc, char *argv[])
     return 0;
 
 endpoint_error:
-    mainloop.free_endpoints(&opt);
+    free_endpoints_options_strings(&opt);
+
     free(opt.logs_dir);
 
 close_log:

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -889,7 +889,7 @@ fail:
 
 int main(int argc, char *argv[])
 {
-    Mainloop &mainloop = Mainloop::init();
+    Mainloop mainloop;
 
     Log::open();
 
@@ -907,9 +907,6 @@ int main(int argc, char *argv[])
     Log::set_max_level((Log::Level) opt.debug_log_level);
 
     dbg("Cmd line and options parsed");
-
-    if (mainloop.open() < 0)
-        goto close_log;
 
     if (opt.tcp_port == ULONG_MAX)
         opt.tcp_port = MAVLINK_TCP_PORT;

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -69,6 +69,7 @@ Mainloop::Mainloop()
 
 Mainloop::~Mainloop()
 {
+    free_endpoints();
     instance = nullptr;
 }
 
@@ -141,11 +142,11 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 {
     bool unknown = true;
 
-    for (Endpoint **e = g_endpoints; *e != nullptr; e++) {
-        if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
-            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", (*e)->fd, msg_id, target_sysid,
+    for (const auto& e : _endpoints) {
+        if (e->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
+            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->fd, msg_id, target_sysid,
                       target_compid, sender_sysid, sender_compid);
-            write_msg(*e, buf);
+            write_msg(e.get(), buf);
             e->postprocess_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id);
             unknown = false;
         }
@@ -359,10 +360,8 @@ bool Mainloop::_log_aggregate_timeout(void *data)
         _errors_aggregate.msg_to_unknown = 0;
     }
 
-    if (g_endpoints) {
-        for (Endpoint **e = g_endpoints; *e != nullptr; e++) {
-            (*e)->log_aggregate(LOG_AGGREGATE_INTERVAL_SEC);
-        }
+    for (const auto& e : _endpoints) {
+        e->log_aggregate(LOG_AGGREGATE_INTERVAL_SEC);
     }
 
     for (auto *t = g_tcp_endpoints; t; t = t->next) {
@@ -373,8 +372,9 @@ bool Mainloop::_log_aggregate_timeout(void *data)
 
 void Mainloop::print_statistics()
 {
-    for (Endpoint **e = g_endpoints; *e != nullptr; e++)
-        (*e)->print_statistics();
+    for (const auto & e : _endpoints) {
+        e->print_statistics();
+    }
     for (auto i: _dynamic_endpoints) {
         i.second->print_statistics();
     }
@@ -430,22 +430,19 @@ bool Mainloop::_add_dynamic_endpoint(std::string name, std::string command, Endp
 
 bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
 {
-    unsigned n_endpoints = 0, i = 0;
+    unsigned n_endpoints = 0;
     struct endpoint_config *conf;
 
     for (conf = opt->endpoints; conf; conf = conf->next) {
         if (conf->type != Tcp) {
             // TCP endpoints are efemeral, that's why they don't
-            // live on `g_endpoints` array, but on `g_tcp_endpoints` list
+            // live on `_endpoints` array, but on `g_tcp_endpoints` list
             n_endpoints++;
         }
     }
 
     if (opt->logs_dir)
         n_endpoints++;
-
-    g_endpoints = (Endpoint**) calloc(n_endpoints + 1, sizeof(Endpoint*));
-    assert_or_return(g_endpoints, false);
 
     for (conf = opt->endpoints; conf; conf = conf->next) {
         switch (conf->type) {
@@ -467,9 +464,8 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                     return false;
             }
 
-            g_endpoints[i] = uart.release();
-            mainloop.add_fd(g_endpoints[i]->fd, g_endpoints[i], EPOLLIN);
-            i++;
+            mainloop.add_fd(uart->fd, uart.get(), EPOLLIN);
+            _endpoints.push_back(std::move(uart));
             break;
         }
         case Udp: {
@@ -487,9 +483,8 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                 }
             }
 
-            g_endpoints[i] = udp.release();
-            mainloop.add_fd(g_endpoints[i]->fd, g_endpoints[i], EPOLLIN);
-            i++;
+            mainloop.add_fd(udp->fd, udp.get(), EPOLLIN);
+            _endpoints.push_back(std::move(udp));
             break;
         }
         case Tcp: {
@@ -516,22 +511,26 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         }
     }
 
-    if (opt->tcp_port)
+    if (opt->tcp_port) {
         g_tcp_fd = tcp_open(opt->tcp_port);
+    }
+
 
     if (opt->logs_dir) {
+        std::unique_ptr<LogEndpoint> log_endpoint;
         if (opt->mavlink_dialect == Ardupilotmega) {
-            _log_endpoint
-                = new BinLog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files);
+            log_endpoint.reset(
+                new BinLog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files));
         } else if (opt->mavlink_dialect == Common) {
-            _log_endpoint
-                = new ULog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files);
+            log_endpoint.reset(
+                new ULog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files));
         } else {
-            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode, opt->min_free_space,
-                                        opt->max_log_files);
+            log_endpoint.reset(new AutoLog(opt->logs_dir, opt->log_mode, opt->min_free_space,
+                                        opt->max_log_files));
         }
+        _log_endpoint = log_endpoint.get();
         _log_endpoint->mark_unfinished_logs();
-        g_endpoints[i] = _log_endpoint;
+        _endpoints.push_back(std::move(log_endpoint));
     }
 
     if (opt->report_msg_statistics)
@@ -540,12 +539,11 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
     return true;
 }
 
-void Mainloop::free_endpoints(struct options *opt)
+void Mainloop::free_endpoints()
 {
-    for (Endpoint **e = g_endpoints; *e; e++) {
-        delete *e;
-    }
-    free(g_endpoints);
+    // XXX not explicitly needed since only called from constructor; leaving
+    // here until remainder clean.
+    _endpoints.clear();
 
     for (auto *t = g_tcp_endpoints; t;) {
         auto next = t->next;
@@ -559,19 +557,6 @@ void Mainloop::free_endpoints(struct options *opt)
     }
     _pipe_commands.clear();
     _dynamic_endpoints.clear();
-
-    for (auto e = opt->endpoints; e;) {
-        auto next = e->next;
-        if (e->type == Udp || e->type == Tcp) {
-            free(e->address);
-        } else {
-            free(e->device);
-            delete e->bauds;
-        }
-        free(e->name);
-        free(e);
-        e = next;
-    }
 }
 
 int Mainloop::tcp_open(unsigned long tcp_port)

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -70,6 +70,7 @@ Mainloop::Mainloop()
 Mainloop::~Mainloop()
 {
     free_endpoints();
+    _del_timeouts(); // needs to happen after endpoints are freed
     instance = nullptr;
 }
 
@@ -171,6 +172,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
                 should_process_tcp_hangups = true;
             }
             unknown = false;
+            e->endpoint->postprocess_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id);
         }
     }
 
@@ -475,12 +477,26 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                 return false;
             }
 
+            udp->set_coalescing(conf->coalesce_bytes, conf->coalesce_ms);
+
             if (conf->filter) {
-                char *token = strtok(conf->filter, ",");
+                char *local_filter = strdup(conf->filter);
+                char *token = strtok(local_filter, ",");
                 while (token != nullptr) {
                     udp->add_message_to_filter(atoi(token));
                     token = strtok(nullptr, ",");
                 }
+                free(local_filter);
+            }
+
+            if (conf->coalesce_nodelay) {
+                char *local_nodelay = strdup(conf->coalesce_nodelay);
+                char *token = strtok(local_nodelay, ",");
+                while (token != nullptr) {
+                    udp->add_message_to_nodelay(atoi(token));
+                    token = strtok(nullptr, ",");
+                }
+                free(local_nodelay);
             }
 
             mainloop.add_fd(udp->fd, udp.get(), EPOLLIN);

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -25,7 +25,6 @@
 #include <sys/timerfd.h>
 #include <unistd.h>
 
-#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -38,68 +37,49 @@ static std::atomic<bool> should_exit {false};
 #define TIMEOUT_LOG_SHUTDOWN_US     5000000ULL // number of microseconds we wait until we give up trying to stop log streaming
                                         // after a shutdown of mavlink router was requested
 
-
-Mainloop Mainloop::_instance{};
-bool Mainloop::_initialized = false;
-
-static void exit_signal_handler(int signum)
-{
-    Mainloop::request_exit();
-}
-
-static void setup_signal_handlers()
-{
-    struct sigaction sa = { };
-
-    sa.sa_flags = SA_NOCLDSTOP;
-    sa.sa_handler = exit_signal_handler;
-    sigaction(SIGTERM, &sa, nullptr);
-    sigaction(SIGINT, &sa, nullptr);
-
-    sa.sa_handler = SIG_IGN;
-    sigaction(SIGPIPE, &sa, nullptr);
-}
-
-Mainloop &Mainloop::init()
-{
-    assert(_initialized == false);
-
-    _initialized = true;
-
-    return _instance;
-}
-
 static const char* pipe_path = "/tmp/mavlink_router_pipe";
 
-void Mainloop::request_exit()
-{
-    should_exit.store(true, std::memory_order_relaxed);
-}
+Mainloop* Mainloop::instance = nullptr;
 
-int Mainloop::open()
+Mainloop::Mainloop()
 {
-    if (epollfd != -1)
-        return -EBUSY;
+    if (instance) {
+        throw std::logic_error("Only one mainloop instance must exist at a given time");
+    }
 
     epollfd = epoll_create1(EPOLL_CLOEXEC);
 
     if (epollfd == -1) {
-        log_error("%m");
-        return -1;
+        throw std::runtime_error(std::string("epoll_create: ") + strerror(errno));
     }
 
-    if (mkfifo(pipe_path, 0777) == -1) {
-        log_error("%m");
+    // XXX: this is bad for testing/multi-instantiation.
+    if (mkfifo(pipe_path, 0777) == -1 && errno != EEXIST) {
+        throw std::runtime_error(std::string("mkfifo: ") + strerror(errno));
     }
 
-    _pipefd = ::open(pipe_path, O_RDWR);
+    _pipefd = ::open(pipe_path, O_RDWR | O_CLOEXEC | O_NONBLOCK);
     if (_pipefd == -1) {
-        log_error("%m");
-        return -1;
+        throw std::runtime_error(std::string("open pipe: ") + strerror(errno));
     }
     add_fd(_pipefd, &_pipefd, EPOLLIN);
 
-    return 0;
+    instance = this;
+}
+
+Mainloop::~Mainloop()
+{
+    instance = nullptr;
+}
+
+Mainloop& Mainloop::get_instance()
+{
+    return *instance;
+}
+
+void Mainloop::request_exit()
+{
+    _should_exit.store(true, std::memory_order_relaxed);
 }
 
 int Mainloop::mod_fd(int fd, void *data, int events)
@@ -285,76 +265,32 @@ accept_error:
 
 void Mainloop::loop()
 {
-    const int max_events = 8;
-    struct epoll_event events[max_events];
-    int r;
-
     if (epollfd < 0)
         return;
 
-    setup_signal_handlers();
+    MainloopSignalHandlers handlers(this);
 
     add_timeout(LOG_AGGREGATE_INTERVAL_SEC * MSEC_PER_SEC,
                 std::bind(&Mainloop::_log_aggregate_timeout, this, std::placeholders::_1), this);
 
-    usec_t timestamp_stop_requested = 0;
-    while (!should_exit.load(std::memory_order_relaxed)) {
-        int i;
-
-        r = epoll_wait(epollfd, events, max_events, -1);
-        if (r < 0 && errno == EINTR)
-            continue;
-        for (i = 0; i < r; i++) {
-            if (events[i].data.ptr == &_pipefd) {
-                _handle_pipe();
-                continue;
-            } else if (events[i].data.ptr == &g_tcp_fd) {
-                handle_tcp_connection();
-                continue;
-            }
-            Pollable *p = static_cast<Pollable *>(events[i].data.ptr);
-
-            if (events[i].events & EPOLLIN) {
-              int rd = p->handle_read();
-                if (rd < 0 && !p->is_valid()) {
-                    // Only TcpEndpoint may become invalid after a read
-                    should_process_tcp_hangups = true;
-                }
-            }
-
-            if (events[i].events & EPOLLOUT) {
-                if (!p->handle_canwrite()) {
-                    mod_fd(p->fd, p, EPOLLIN);
-                }
-            }
-            if (events[i].events & EPOLLERR) {
-                log_error("poll error for fd %i, closing it", p->fd);
-                remove_fd(p->fd);
-                // make poll errors fatal so that an external component can
-                // restart mavlink-router
-                request_exit();
-            }
-
-            // we should exit the router, make sure to stop the logendpoint properly (e.g. wait for ACK)
-            // we will try for max TIMEOUT_LOG_SHUTDOWN_US to shut down the log stream before we give up and exit anyways
-            if (should_exit.load(std::memory_order_relaxed)) {
-                if (_log_endpoint && timestamp_stop_requested == 0) {
-                    // log streaming is active, start timing
-                    timestamp_stop_requested = now_usec();
-                    _log_endpoint->stop();
-                }
-            }
-        }
-
-        if (should_process_tcp_hangups) {
-            process_tcp_hangups();
-        }
-
-        _del_timeouts();
+    while (!_should_exit.load(std::memory_order_relaxed)) {
+        run_single(-1);
     }
-
-    if (_log_endpoint)
+    // This is a bit weird, but models previous behavior: run event handling a
+    // bit more to allow log end point to shutdown. This should instead be
+    // handled in main taking care of log_endpoint *only*.
+    if (_log_endpoint) {
         _log_endpoint->stop();
+        usec_t now = now_usec();
+        usec_t deadline = now + TIMEOUT_LOG_SHUTDOWN_US;
+
+        while (now < deadline) {
+            run_single((deadline - now) / 1000);
+            now = now_usec();
+        }
+
+        _log_endpoint->stop();
+    }
 
     // free all remaning Timeouts
     while (_timeouts) {
@@ -363,6 +299,56 @@ void Mainloop::loop()
         remove_fd(current->fd);
         delete current;
     }
+}
+
+int Mainloop::run_single(int timeout_msec)
+{
+    constexpr int max_events = 8;
+    struct epoll_event events[max_events];
+
+    int r = epoll_wait(epollfd, events, max_events, timeout_msec);
+    if (r <= 0) {
+        return 0;
+    }
+    for (int i = 0; i < r; i++) {
+        if (events[i].data.ptr == &_pipefd) {
+            _handle_pipe();
+            continue;
+        } else if (events[i].data.ptr == &g_tcp_fd) {
+            handle_tcp_connection();
+            continue;
+        }
+        Pollable *p = static_cast<Pollable *>(events[i].data.ptr);
+
+        if (events[i].events & EPOLLIN) {
+            r = p->handle_read();
+            if (r < 0 && !p->is_valid()) {
+                // Only TcpEndpoint may become invalid after a read
+                should_process_tcp_hangups = true;
+            }
+        }
+
+        if (events[i].events & EPOLLOUT) {
+            if (!p->handle_canwrite()) {
+                mod_fd(p->fd, p, EPOLLIN);
+            }
+        }
+        if (events[i].events & EPOLLERR) {
+            log_error("poll error for fd %i, closing it", p->fd);
+            remove_fd(p->fd);
+            // make poll errors fatal so that an external component can
+            // restart mavlink-router
+            request_exit();
+        }
+    }
+
+    if (should_process_tcp_hangups) {
+        process_tcp_hangups();
+    }
+
+    _del_timeouts();
+
+    return r;
 }
 
 bool Mainloop::_log_aggregate_timeout(void *data)
@@ -778,3 +764,38 @@ void Mainloop::_handle_pipe()
         _add_dynamic_endpoint(name, command, udp.release());
     }
 }
+
+MainloopSignalHandlers::MainloopSignalHandlers(Mainloop* mainloop)
+{
+    if (mainloop_instance) {
+        throw std::logic_error("Only one MainloopSignalHandlers instance must exist at a given time");
+    }
+
+    mainloop_instance = mainloop;
+
+    struct sigaction sa = { };
+
+    sa.sa_flags = SA_NOCLDSTOP;
+    sa.sa_handler = &signal_handler_function;
+    sigaction(SIGTERM, &sa, &_old_sigterm);
+    sigaction(SIGINT, &sa, &_old_sigint);
+
+    sa.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &sa, &_old_sigpipe);
+}
+
+MainloopSignalHandlers::~MainloopSignalHandlers()
+{
+    sigaction(SIGTERM, &_old_sigterm, nullptr);
+    sigaction(SIGINT, &_old_sigint, nullptr);
+    sigaction(SIGPIPE, &_old_sigpipe, nullptr);
+
+    mainloop_instance = nullptr;
+}
+
+void MainloopSignalHandlers::signal_handler_function(int signo)
+{
+    mainloop_instance->request_exit();
+}
+
+Mainloop* MainloopSignalHandlers::mainloop_instance{nullptr};

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -70,7 +70,6 @@ public:
     void set_timeout(Timeout *t, uint32_t timeout_msec);
     void del_timeout(Timeout *t);
 
-    void free_endpoints(struct options *opt);
     bool add_endpoints(Mainloop &mainloop, struct options *opt);
     bool remove_dynamic_endpoint(Endpoint *endpoint);
 
@@ -90,17 +89,27 @@ public:
      */
     void request_exit();
 
+    /*
+     * Expose list of registered endpoints (primarily for direct interaction
+     * in tests).
+     */
+    inline const std::vector<std::unique_ptr<Endpoint>>& endpoints() const
+    {
+        return _endpoints;
+    }
+
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;
 
     endpoint_entry *g_tcp_endpoints = nullptr;
-    Endpoint **g_endpoints = nullptr;
+    std::vector<std::unique_ptr<Endpoint>> _endpoints;
     int g_tcp_fd = -1;
     LogEndpoint *_log_endpoint = nullptr;
 
     std::map<std::string, std::string> _pipe_commands;
     std::map<std::string, Endpoint *> _dynamic_endpoints;
     int _pipefd = -1;
+    struct options* _options{nullptr};
 
     Timeout *_timeouts = nullptr;
 
@@ -110,6 +119,7 @@ private:
         uint32_t msg_to_unknown = 0;
     } _errors_aggregate;
 
+    void free_endpoints();
     int tcp_open(unsigned long tcp_port);
     void _del_timeouts();
     int _add_tcp_endpoint(TcpEndpoint *tcp);

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -17,6 +17,9 @@
  */
 #pragma once
 
+#include <signal.h>
+
+#include <atomic>
 #include <string>
 #include <map>
 
@@ -33,11 +36,29 @@ struct endpoint_entry {
 
 class Mainloop {
 public:
-    int open();
+    /*
+     * Sets up main event handling loop. There can be only a single instance
+     * of it in the whole process at any given point in time.
+     */
+    Mainloop();
+    Mainloop(const Mainloop &) = delete;
+    Mainloop &operator=(const Mainloop &) = delete;
+
+    ~Mainloop();
+
     int add_fd(int fd, void *data, int events);
     int mod_fd(int fd, void *data, int events);
     int remove_fd(int fd);
     void loop();
+
+    /*
+     * Runs single iteration of mainloop, i.e. single round of event handling.
+     * This will wait for at most the given time (indefinitely if -1) and
+     * within this time dispatch of all handling events (socket events &
+     * timers.
+     */
+    int run_single(int timeout_msec);
+
     void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
                    int sender_compid, uint32_t msg_id = UINT32_MAX);
     void handle_read(Endpoint *e);
@@ -59,24 +80,15 @@ public:
     bool should_process_tcp_hangups = false;
 
     /*
-     * Return singleton for this class, tied to the main thread. It needds to
-     * be called after a call to Mainloop::init().
+     * Return singleton for this class, tied to the main thread.
      */
-    static Mainloop &get_instance()
-    {
-        assert(_initialized);
-        return _instance;
-    }
+    static Mainloop &get_instance();
 
     /*
-     * Initialize and return singleton.
+     * Request that loop exits "eventually". This (and only this!) function
+     * is async-signal safe.
      */
-    static Mainloop &init();
-
-    /*
-     * Request that loop exits "eventually".
-     */
-    static void request_exit();
+    void request_exit();
 
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;
@@ -92,6 +104,8 @@ private:
 
     Timeout *_timeouts = nullptr;
 
+    std::atomic<bool> _should_exit {false};
+
     struct {
         uint32_t msg_to_unknown = 0;
     } _errors_aggregate;
@@ -105,12 +119,22 @@ private:
     bool _add_dynamic_endpoint(std::string name, std::string command, Endpoint *endpoint);
     void _handle_pipe();
 
-    Mainloop() { }
-    Mainloop(const Mainloop &) = delete;
-    Mainloop &operator=(const Mainloop &) = delete;
+    static Mainloop* instance;
+};
 
-    static Mainloop _instance;
-    static bool _initialized;
+class MainloopSignalHandlers {
+public:
+    explicit MainloopSignalHandlers(Mainloop* mainloop);
+    ~MainloopSignalHandlers();
+
+private:
+    static void signal_handler_function(int signo);
+
+    static Mainloop* mainloop_instance;
+
+    struct sigaction _old_sigterm;
+    struct sigaction _old_sigint;
+    struct sigaction _old_sigpipe;
 };
 
 enum endpoint_type { Tcp, Uart, Udp, Unknown };

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -17,6 +17,9 @@
  */
 #pragma once
 
+#include <string>
+#include <map>
+
 #include "binlog.h"
 #include "comm.h"
 #include "endpoint.h"
@@ -43,10 +46,12 @@ public:
     int write_msg(Endpoint *e, const struct buffer *buf);
     void process_tcp_hangups();
     Timeout *add_timeout(uint32_t timeout_msec, std::function<bool(void*)> cb, const void *data);
+    void set_timeout(Timeout *t, uint32_t timeout_msec);
     void del_timeout(Timeout *t);
 
     void free_endpoints(struct options *opt);
     bool add_endpoints(Mainloop &mainloop, struct options *opt);
+    bool remove_dynamic_endpoint(Endpoint *endpoint);
 
     void print_statistics();
 
@@ -81,6 +86,10 @@ private:
     int g_tcp_fd = -1;
     LogEndpoint *_log_endpoint = nullptr;
 
+    std::map<std::string, std::string> _pipe_commands;
+    std::map<std::string, Endpoint *> _dynamic_endpoints;
+    int _pipefd = -1;
+
     Timeout *_timeouts = nullptr;
 
     struct {
@@ -93,6 +102,8 @@ private:
     void _add_tcp_retry(TcpEndpoint *tcp);
     bool _retry_timeout_cb(void *data);
     bool _log_aggregate_timeout(void *data);
+    bool _add_dynamic_endpoint(std::string name, std::string command, Endpoint *endpoint);
+    void _handle_pipe();
 
     Mainloop() { }
     Mainloop(const Mainloop &) = delete;

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -159,7 +159,10 @@ struct endpoint_config {
             char *address;
             long unsigned port;
             int retry_timeout;
-            bool eavesdropping;
+            bool eavesdropping;     // bind to local port specified, instead of send to remote port
+            int coalesce_ms;        // max time to hold data to try to send packets together
+            int coalesce_bytes;     // never send packets larger than this size
+            char *coalesce_nodelay; // immediately send if a mavlink msg_id is matching this
         };
         struct {
             char *device;

--- a/src/mavlink-router/mainloop_test.cpp
+++ b/src/mavlink-router/mainloop_test.cpp
@@ -6,7 +6,7 @@
 
 class MainLoopTest : public ::testing::Test {
 public:
-    static struct endpoint_config make_udp_endpoint_config(int port)
+    static struct endpoint_config make_udp_endpoint_config(int port, bool coalesce)
     {
         struct endpoint_config cfg {};
         // XXX: need non-const strings here, despite the fact that this is
@@ -24,7 +24,14 @@ public:
         // XXX: not clear about the name of this variable -- it causes socket
         // to be bound to specified port
         cfg.eavesdropping = true;
+        if (coalesce) {
+            cfg.coalesce_bytes = 100;
+            cfg.coalesce_ms = 1;
+        }
         cfg.filter = nullptr;
+        static char nodelay[] = "75,76,77";
+        cfg.coalesce_nodelay = nodelay;
+
         return cfg;
     }
 
@@ -62,7 +69,7 @@ TEST_F(MainLoopTest, termination)
 
 TEST_F(MainLoopTest, create_udp_endpoint)
 {
-    struct endpoint_config cfg = make_udp_endpoint_config(7777);
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, false);
     struct options opts = make_single_endpoint_options(&cfg);
 
     Mainloop mainloop;
@@ -72,7 +79,7 @@ TEST_F(MainLoopTest, create_udp_endpoint)
 
 TEST_F(MainLoopTest, direct_udp_endpoint_send)
 {
-    struct endpoint_config cfg = make_udp_endpoint_config(7777);
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, false);
     struct options opts = make_single_endpoint_options(&cfg);
 
     Mainloop mainloop;
@@ -89,6 +96,155 @@ TEST_F(MainLoopTest, direct_udp_endpoint_send)
     char data[17] = "0123456789abcdef";
     struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
     udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(16, count);
+    EXPECT_EQ(0, std::memcmp("0123456789abcdef", recvbuf, 16));
+
+    ::close(sock);
+}
+
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_time_trigger)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[17] = "0123456789abcdef";
+    struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, MSG_DONTWAIT);
+
+    EXPECT_EQ(-1, count) << "UDP packet coalescing shouldn't have allowed a send yet";
+    EXPECT_EQ(EWOULDBLOCK, errno);
+
+    // allow UDP packet coalescing to expire
+    // XXX: make the timer expire explicitly, instead of waiting for timeout
+    mainloop.run_single(100);
+
+    count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(16, count);
+    EXPECT_EQ(0, std::memcmp("0123456789abcdef", recvbuf, 16));
+
+    ::close(sock);
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_size_trigger)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[110] = {};
+    for (int i = 1; i < 110; i++) data[i] = i;
+
+    const struct buffer buf = {110, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(110, count);
+    EXPECT_EQ(0, std::memcmp(data, recvbuf, 110));
+
+    ::close(sock);
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_size_trigger_from_second)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[55] = {};
+    for (int i = 1; i < 55; i++) data[i] = i;
+
+    struct buffer buf = {55, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, MSG_DONTWAIT);
+
+    EXPECT_EQ(-1, count) << "UDP packet coalescing shouldn't have allowed a send yet";
+    EXPECT_EQ(EWOULDBLOCK, errno);
+
+    buf.len = 50;
+    udp_endpoint->write_msg(&buf);
+
+    count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(55, count);
+    EXPECT_EQ(0, std::memcmp(data, recvbuf, 55));
+
+    // allow UDP packet coalescing to expire
+    // XXX: make the timer expire explicitly, instead of waiting for timeout
+    mainloop.run_single(100);
+
+    memset(recvbuf, 0, 1024);
+    count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(50, count);
+    EXPECT_EQ(0, std::memcmp(data, recvbuf, 50));
+
+    ::close(sock);
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_nodelay)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[17] = "0123456789abcdef";
+    struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+    udp_endpoint->postprocess_msg(0,0,0,0,76);
 
     char recvbuf[1024];
     ssize_t count = ::recv(sock, recvbuf, 1024, 0);

--- a/src/mavlink-router/mainloop_test.cpp
+++ b/src/mavlink-router/mainloop_test.cpp
@@ -3,8 +3,9 @@
 #include <gtest/gtest.h>
 
 TEST(MainLoopTest, termination) {
-    Mainloop& mainloop = Mainloop::init();
-    mainloop.open();
+    Mainloop mainloop;
+
     mainloop.request_exit();
+
     mainloop.loop();
 }

--- a/src/mavlink-router/mainloop_test.cpp
+++ b/src/mavlink-router/mainloop_test.cpp
@@ -1,11 +1,100 @@
 #include "mainloop.h"
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
-TEST(MainLoopTest, termination) {
+class MainLoopTest : public ::testing::Test {
+public:
+    static struct endpoint_config make_udp_endpoint_config(int port)
+    {
+        struct endpoint_config cfg {};
+        // XXX: need non-const strings here, despite the fact that this is
+        // strongly discouraged in general: config data structure is defined
+        // this way
+        static char name[] = "dummy";
+        static char address[] = "127.0.0.1";
+        cfg.type = Udp;
+        cfg.name = name;
+        // XXX: hard-coding address & port in test is ill-advised; API does not
+        // allow injection of sockets.
+        cfg.address = address;
+        cfg.port = port;
+        cfg.retry_timeout = 0;
+        // XXX: not clear about the name of this variable -- it causes socket
+        // to be bound to specified port
+        cfg.eavesdropping = true;
+        cfg.filter = nullptr;
+        return cfg;
+    }
+
+    static struct options make_single_endpoint_options(endpoint_config* cfg)
+    {
+        struct options opts{};
+        opts.endpoints = cfg;
+        return opts;
+    }
+
+    static std::pair<int, sockaddr_in> make_scratch_udp_socket()
+    {
+        int fd = ::socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+        struct sockaddr_in addr;
+        addr.sin_family = AF_INET;
+        addr.sin_port = 0;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+        ::bind(fd, reinterpret_cast<const struct sockaddr*>(&addr), sizeof(addr));
+        socklen_t addrlen = sizeof(addr);
+        ::getsockname(fd, reinterpret_cast<struct sockaddr*>(&addr), &addrlen);
+
+        return {fd, addr};
+    }
+};
+
+TEST_F(MainLoopTest, termination)
+{
     Mainloop mainloop;
 
     mainloop.request_exit();
 
     mainloop.loop();
+}
+
+TEST_F(MainLoopTest, create_udp_endpoint)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[17] = "0123456789abcdef";
+    struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(16, count);
+    EXPECT_EQ(0, std::memcmp("0123456789abcdef", recvbuf, 16));
+
+    ::close(sock);
 }

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -37,6 +37,7 @@ public:
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
+    bool _stop_timeout() override;
 
     const char *_get_logfile_extension() override { return "ulg"; };
 private:


### PR DESCRIPTION
This brings upstream a number of features we've developed at Auterion.

* Dynamic endpoints, which can be added or removed at runtime via a named pipe
* UDP packet coalescing, to reduce packet overhead for certain transport types
* Refactoring of the mainloop, to allow it to be run one iteration at a time to enable unit tests.