### PR TITLE
Timeout timer - change to NONBLOCK otherwise we could hang in a timer read operation

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -542,7 +542,7 @@ Timeout *Mainloop::add_timeout(uint32_t timeout_msec, std::function<bool(void*)>
 
     assert_or_return(t, NULL);
 
-    t->fd = timerfd_create(CLOCK_MONOTONIC, 0);
+    t->fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
     if (t->fd < 0) {
         log_error("Unable to create timerfd: %m");
         goto error;


### PR DESCRIPTION
This could happen if in the same ground of events in the mainloop we have and operation disarming the timer followed by a timer read. This is a corner case that can happen more often when using mavlink message coalescing since the timer is continuously used. When this issue occurs the entire mavlink router mainloop is hanging since the timer read is done in this loop.

Timer read where we would get stuck: https://github.com/mavlink-router/mavlink-router/blob/51c72ffdce5ffb9d3f07010cd00de9dca4f8af4c/src/mavlink-router/timeout.cpp#L34