### PR TITLE
Do not exit on TCP disconnects

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,4 +207,6 @@ AC_MSG_RESULT([
 
 	C compiler:		${CC}
 	C++ compiler:		${CXX}
+
+	enable_tests:           ${HAVE_GTEST}
 ])

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -890,6 +890,7 @@ fail:
 int main(int argc, char *argv[])
 {
     Mainloop &mainloop = Mainloop::init();
+    int retcode;
 
     Log::open();
 
@@ -917,7 +918,7 @@ int main(int argc, char *argv[])
     if (!mainloop.add_endpoints(mainloop, &opt))
         goto endpoint_error;
 
-    mainloop.loop();
+    retcode = mainloop.loop();
 
     mainloop.free_endpoints(&opt);
 
@@ -925,7 +926,7 @@ int main(int argc, char *argv[])
 
     Log::close();
 
-    return 0;
+    return retcode ? EXIT_FAILURE : 0;
 
 endpoint_error:
     mainloop.free_endpoints(&opt);

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -253,14 +253,14 @@ accept_error:
     delete tcp;
 }
 
-void Mainloop::loop()
+int Mainloop::loop()
 {
     const int max_events = 8;
     struct epoll_event events[max_events];
     int r;
 
     if (epollfd < 0)
-        return;
+        return -EINVAL;
 
     setup_signal_handlers();
 
@@ -329,6 +329,8 @@ void Mainloop::loop()
         remove_fd(current->fd);
         delete current;
     }
+
+    return 0;
 }
 
 bool Mainloop::_log_aggregate_timeout(void *data)

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -38,7 +38,7 @@ bool Mainloop::_initialized = false;
 
 static void exit_signal_handler(int signum)
 {
-    Mainloop::request_exit();
+    Mainloop::instance().request_exit();
 }
 
 static void setup_signal_handlers()
@@ -60,6 +60,11 @@ Mainloop &Mainloop::init()
 
     _initialized = true;
 
+    return _instance;
+}
+
+Mainloop &Mainloop::instance()
+{
     return _instance;
 }
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -319,7 +319,7 @@ int Mainloop::loop()
                  * mavlink-router
                  */
                 if (p->is_valid())
-                    request_exit(0);
+                    request_exit(EXIT_FAILURE);
             }
         }
 

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -34,7 +34,7 @@ public:
     int add_fd(int fd, void *data, int events);
     int mod_fd(int fd, void *data, int events);
     int remove_fd(int fd);
-    void loop();
+    int loop();
     void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
                    int sender_compid, uint32_t msg_id = UINT32_MAX);
     void handle_read(Endpoint *e);

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -68,10 +68,13 @@ public:
      */
     static Mainloop &init();
 
+    static Mainloop &instance();
+
     /*
-     * Request that loop exits "eventually".
+     * Request that loop exits on next iteration.
      */
-    static void request_exit();
+    void request_exit();
+
 
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -73,7 +73,7 @@ public:
     /*
      * Request that loop exits on next iteration.
      */
-    void request_exit();
+    void request_exit(int retcode);
 
 
 private:
@@ -89,6 +89,8 @@ private:
     struct {
         uint32_t msg_to_unknown = 0;
     } _errors_aggregate;
+
+    int _retcode;
 
     int tcp_open(unsigned long tcp_port);
     void _del_timeouts();

--- a/src/mavlink-router/mainloop_test.cpp
+++ b/src/mavlink-router/mainloop_test.cpp
@@ -5,6 +5,15 @@
 TEST(MainLoopTest, termination) {
     Mainloop& mainloop = Mainloop::init();
     mainloop.open();
-    mainloop.request_exit();
-    mainloop.loop();
+    mainloop.request_exit(0);
+    int ret = mainloop.loop();
+    EXPECT_EQ(0, ret);
+}
+
+TEST(MainLoopTest, wrong_termination) {
+    Mainloop& mainloop = Mainloop::init();
+    mainloop.open();
+    mainloop.request_exit(-1);
+    int ret = mainloop.loop();
+    EXPECT_EQ(-1, ret);
 }


### PR DESCRIPTION
TCP connections are expected to be dynamic. Just like we accept new
connection on the fly, we should also gracefully accept disconnects.
This was the behavior before, but change when we decided to handle UART
disconnections as fatal in 7e7ea939c8d7 ("mainloop: handle epoll_wait error").
For UART, this should not be common as the OS is simply removing the
device under us due to physical disconnection. This restores the previous
behavior for TCP.

In a poll loop it's usual to handle the POLLERR before, but in this case
we leave it after the POLLIN/POLLOUT. Even if we have a POLLERR
we allow the read()/write() calls to be done, so to give the endpoint
the chance to set the `is_valid()` flag.

While at it, fix minor coding style on indentation.

Fix: #252