### PR TITLE
Add notion of critical endpoint. Quit on error on critical endpoints.

### DIFF
--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -220,6 +220,7 @@ public:
     }
 
     bool is_valid() override { return _valid; };
+    bool is_critical() override { return false; };
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override;

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -310,16 +310,12 @@ int Mainloop::loop()
             if (events[i].events & EPOLLERR) {
                 log_error("poll error for fd %i", p->fd);
 
-                /*
-                 * TCP Pollables can be added/removed dynamically and
-                 * is_valid() is set when it becomes not available anymore.
-                 * Otherwise it's a unkonwn error or another bus has a
-                 * unexpected disconnect (e.g. when removing a usb-serial
-                 * device), so make it fatal: external components may restart
-                 * mavlink-router
-                 */
-                if (p->is_valid())
+                if (p->is_critical()) {
+                    log_error("Critical fd %i got error, exiting", p->fd);
                     request_exit(EXIT_FAILURE);
+                } else {
+                    log_debug("Non-critical fd %i, error is okay.", p->fd);
+                }
             }
         }
 

--- a/src/mavlink-router/pollable.h
+++ b/src/mavlink-router/pollable.h
@@ -33,4 +33,10 @@ public:
      * from poll.
      */
     virtual bool is_valid() { return true; };
+
+    /**
+     * If a pollable is critical, a poll error will result in
+     * router exit.
+     */
+    virtual bool is_critical() { return true; };
 };


### PR DESCRIPTION
Related to issue #252 .

This proposal adds a boolean to indicate if a connection is critical or not. When a serial port is unplugged, mavlink-router should quit, but when a tcp connection breaks down, this is okay.