### PR TITLE
Disable Nagle Algorithm on TCP sockets to reduce transport latency

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <net/if.h>
+#include <netinet/tcp.h>
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <stdio.h>
@@ -959,6 +960,12 @@ int TcpEndpoint::accept(int listener_fd)
         return -1;
 
     log_info("TCP connection [%d] accepted", fd);
+
+    int tcp_nodelay_state = 1;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *) &tcp_nodelay_state, sizeof(int)) < 0) {
+        log_error("Setting TCP_NODELAY failed [%d]", fd);
+        return -1;
+    }
 
     return fd;
 }


### PR DESCRIPTION
To reduce the latency introduced by TCP socket in real time systems it is recommended to disable aggregation on the transport level.
While aggregation is on the TCP endpoint Introduced latencies of up to 50 milliseconds to some of the mavlink message.
While aggregation is off the TCP endpoint Introduced latencies of 2-3 milliseconds consistently.

Further Reading:
https://en.wikipedia.org/wiki/Nagle%27s_algorithm