### PR TITLE
configure.ac: fix a typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ AC_ARG_ENABLE(systemd, AC_HELP_STRING([--disable-systemd],
 		[disable systemd integration]), [enable_systemd=${enableval}])
 AM_CONDITIONAL(SYSTEMD, test "${enable_systemd}" != "no")
 
-AC_ARG_ENABLE(enable_ipv6, AC_HELP_STRING([--disable-ipv6],
+AC_ARG_ENABLE(ipv6, AC_HELP_STRING([--disable-ipv6],
 		[disable IPv6 capability]), [enable_ipv6=${enableval}])
 if (test "${enable_ipv6}" != "no"); then
 	AC_DEFINE([ENABLE_IPV6], [], [Enable IPv6])


### PR DESCRIPTION
enable_ipv6 should be ipv6, or else we get a following error:
| --enable-ipv6 [unknown-configure-option]

Signed-off-by: Ming Liu <liu.ming50@gmail.com>