### PR TITLE
DOCS: Fix default TCP port in the sample config

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -114,7 +114,7 @@
 # Following, an example of configuration file:
 [General]
 #Mavlink-router serves on this TCP port
-TcpServerPort=5790
+TcpServerPort=5760
 ReportStats=false
 MavlinkDialect=auto
 


### PR DESCRIPTION
The `TcpServerPort` does not match the default value mentioned in the documentation and the code.