### PR TITLE
gitmodules: use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "modules/mavlink_c_library_v2"]
     path = modules/mavlink_c_library_v2
-    url = git@github.com:mavlink/c_library_v2.git
+    url = https://github.com/mavlink/c_library_v2.git


### PR DESCRIPTION
Otherwise it doensn't work for people without authenticating, or without
a ssh key.

Fix: #292