### PR TITLE
Run clang-format on everything, add new CI workflow to check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,11 +13,18 @@ SpaceAfterCStyleCast: false
 SpaceInEmptyParentheses: false
 
 AlignAfterOpenBracket: true
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveMacros: Consecutive
 Cpp11BracedListStyle: true
 SpaceBeforeCpp11BracedList: false
 IndentCaseLabels: false
+IndentPPDirectives: AfterHash
 NamespaceIndentation: None
+
+FixNamespaceComments: true
+ReflowComments: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,23 +1,23 @@
 ---
-BasedOnStyle:    WebKit
+BasedOnStyle: WebKit
+Language: Cpp
+Standard: Cpp11
+
+TabWidth: 4
+ColumnLimit: 100
+SortIncludes: true
+
+DerivePointerAlignment: false
+PointerAlignment: Right
+SpaceAfterCStyleCast: false
+SpaceInEmptyParentheses: false
 
 AlignAfterOpenBracket: true
 AlignEscapedNewlinesLeft: true
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
-ColumnLimit: 100
 Cpp11BracedListStyle: true
 SpaceBeforeCpp11BracedList: false
-DerivePointerAlignment: false
 IndentCaseLabels: false
-SpaceAfterCStyleCast: false
-Language: Cpp
 NamespaceIndentation: None
-PointerAlignment: Right
-SortIncludes: true
-SpaceAfterCStyleCast: false
-SpaceInEmptyParentheses: false
-Standard: Cpp11
-TabWidth: 4
-...

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,15 @@
+name: clang-format Check
+
+on: [push, pull_request]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run clang-format style check on src directory
+        uses: jidicula/clang-format-action@v4.3.0
+        with:
+          clang-format-version: "13"
+          check-path: "src"

--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -32,8 +32,9 @@ bool BinLog::_logging_start_timeout()
 {
     mavlink_message_t msg;
 
-    mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, _target_system_id,
-                                             MAV_COMP_ID_ALL, MAV_REMOTE_LOG_DATA_BLOCK_START, 1);
+    mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg,
+                                             _target_system_id, MAV_COMP_ID_ALL,
+                                             MAV_REMOTE_LOG_DATA_BLOCK_START, 1);
 
     _send_msg(&msg, _target_system_id);
 
@@ -67,8 +68,9 @@ void BinLog::_send_stop()
 {
     mavlink_message_t msg;
 
-    mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, _target_system_id,
-                                             MAV_COMP_ID_ALL, MAV_REMOTE_LOG_DATA_BLOCK_STOP, 1);
+    mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg,
+                                             _target_system_id, MAV_COMP_ID_ALL,
+                                             MAV_REMOTE_LOG_DATA_BLOCK_STOP, 1);
     _send_msg(&msg, _target_system_id);
 }
 
@@ -134,7 +136,7 @@ int BinLog::write_msg(const struct buffer *buffer)
         binlog_data
             = (mavlink_remote_log_data_block_t *)alloca(sizeof(mavlink_remote_log_data_block_t));
         memcpy(binlog_data, payload, payload_len);
-        memset((uint8_t*)binlog_data + payload_len, 0, trimmed_zeros);
+        memset((uint8_t *)binlog_data + payload_len, 0, trimmed_zeros);
     } else {
         binlog_data = (mavlink_remote_log_data_block_t *)payload;
     }
@@ -167,7 +169,8 @@ void BinLog::_send_ack(uint32_t seqno)
     // Message filled a gap, or is duplicated. just send the ack
     if (seqno < _last_acked_seqno) {
         mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg,
-                                                 _target_system_id, MAV_COMP_ID_ALL, seqno, MAV_REMOTE_LOG_DATA_BLOCK_ACK);
+                                                 _target_system_id, MAV_COMP_ID_ALL, seqno,
+                                                 MAV_REMOTE_LOG_DATA_BLOCK_ACK);
         _send_msg(&msg, _target_system_id);
         return;
     }
@@ -177,13 +180,15 @@ void BinLog::_send_ack(uint32_t seqno)
     // Send nacks regarding unseen seqno
     for (uint32_t i = _last_acked_seqno + 1; i < seqno; i++) {
         mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg,
-                                                 _target_system_id, MAV_COMP_ID_ALL, seqno, MAV_REMOTE_LOG_DATA_BLOCK_NACK);
+                                                 _target_system_id, MAV_COMP_ID_ALL, seqno,
+                                                 MAV_REMOTE_LOG_DATA_BLOCK_NACK);
         _send_msg(&msg, _target_system_id);
     }
 
     // Send ack to seen seqno
-    mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, _target_system_id,
-                                             MAV_COMP_ID_ALL, seqno, MAV_REMOTE_LOG_DATA_BLOCK_ACK);
+    mavlink_msg_remote_log_block_status_pack(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg,
+                                             _target_system_id, MAV_COMP_ID_ALL, seqno,
+                                             MAV_REMOTE_LOG_DATA_BLOCK_ACK);
     _send_msg(&msg, _target_system_id);
     _last_acked_seqno = seqno;
 }

--- a/src/binlog.h
+++ b/src/binlog.h
@@ -43,6 +43,7 @@ protected:
     bool _logging_start_timeout() override;
 
     const char *_get_logfile_extension() override { return "bin"; };
+
 private:
     uint32_t _last_acked_seqno = 0;
 

--- a/src/common/dbg.h
+++ b/src/common/dbg.h
@@ -30,17 +30,17 @@
 #include "log.h"
 
 #ifndef LOG_DEBUG
-#define dbg(...) \
-    do {         \
-    } while (0)
+#    define dbg(...) \
+        do {         \
+        } while (0)
 #else
-#ifdef dbg
-#undef dbg
-#endif
+#    ifdef dbg
+#        undef dbg
+#    endif
 
-#ifndef LOG_DEBUG_LEVEL
-#define LOG_DEBUG_LEVEL Log::Level::DEBUG
-#endif
+#    ifndef LOG_DEBUG_LEVEL
+#        define LOG_DEBUG_LEVEL Log::Level::DEBUG
+#    endif
 
-#define dbg(...) Log::log(LOG_DEBUG_LEVEL, __VA_ARGS__)
+#    define dbg(...) Log::log(LOG_DEBUG_LEVEL, __VA_ARGS__)
 #endif

--- a/src/common/dbg.h
+++ b/src/common/dbg.h
@@ -30,15 +30,17 @@
 #include "log.h"
 
 #ifndef LOG_DEBUG
-#  define dbg(...) do { } while (0)
+#define dbg(...) \
+    do {         \
+    } while (0)
 #else
-#  ifdef dbg
-#    undef dbg
-#  endif
+#ifdef dbg
+#undef dbg
+#endif
 
-#  ifndef LOG_DEBUG_LEVEL
-#    define LOG_DEBUG_LEVEL Log::Level::DEBUG
-#  endif
+#ifndef LOG_DEBUG_LEVEL
+#define LOG_DEBUG_LEVEL Log::Level::DEBUG
+#endif
 
-#  define dbg(...) Log::log(LOG_DEBUG_LEVEL, __VA_ARGS__)
+#define dbg(...) Log::log(LOG_DEBUG_LEVEL, __VA_ARGS__)
 #endif

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -24,12 +24,12 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-#define COLOR_RED "\033[31m"
+#define COLOR_RED       "\033[31m"
 #define COLOR_LIGHTBLUE "\033[34;1m"
-#define COLOR_YELLOW "\033[33;1m"
-#define COLOR_ORANGE "\033[0;33m"
-#define COLOR_WHITE "\033[37;1m"
-#define COLOR_RESET "\033[0m"
+#define COLOR_YELLOW    "\033[33;1m"
+#define COLOR_ORANGE    "\033[0;33m"
+#define COLOR_WHITE     "\033[37;1m"
+#define COLOR_RESET     "\033[0m"
 
 Log::Level Log::_max_level = Level::INFO;
 int Log::_target_fd = -1;

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -19,17 +19,17 @@
 
 #include <assert.h>
 #include <limits.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/uio.h>
+#include <unistd.h>
 
-#define COLOR_RED          "\033[31m"
-#define COLOR_LIGHTBLUE    "\033[34;1m"
-#define COLOR_YELLOW       "\033[33;1m"
-#define COLOR_ORANGE       "\033[0;33m"
-#define COLOR_WHITE        "\033[37;1m"
-#define COLOR_RESET        "\033[0m"
+#define COLOR_RED "\033[31m"
+#define COLOR_LIGHTBLUE "\033[34;1m"
+#define COLOR_YELLOW "\033[33;1m"
+#define COLOR_ORANGE "\033[0;33m"
+#define COLOR_WHITE "\033[37;1m"
+#define COLOR_RESET "\033[0m"
 
 Log::Level Log::_max_level = Level::INFO;
 int Log::_target_fd = -1;
@@ -61,7 +61,7 @@ int Log::open()
     assert_or_return(_target_fd < 0, -1);
 
     /* for now, only logging is supported only to stderr */
-    _target_fd =  STDERR_FILENO;
+    _target_fd = STDERR_FILENO;
 
     if (isatty(_target_fd))
         _show_colors = true;
@@ -84,7 +84,7 @@ void Log::set_max_level(Level level)
 
 void Log::logv(Level level, const char *format, va_list ap)
 {
-    struct iovec iovec[6] = { };
+    struct iovec iovec[6] = {};
     const char *color;
     int n = 0;
     char buffer[LINE_MAX];

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -56,10 +56,10 @@ protected:
 #define log_warning(...) Log::log(Log::Level::WARNING, __VA_ARGS__)
 #define log_error(...) Log::log(Log::Level::ERROR, __VA_ARGS__)
 
-#define assert_or_return(exp, ...)                              \
-    do {                                                        \
-        if (__builtin_expect(!(exp), 0)) {                      \
-            log_warning("Expresssion `" #exp "` is false");     \
-            return __VA_ARGS__;                                 \
-        }                                                       \
+#define assert_or_return(exp, ...)                          \
+    do {                                                    \
+        if (__builtin_expect(!(exp), 0)) {                  \
+            log_warning("Expresssion `" #exp "` is false"); \
+            return __VA_ARGS__;                             \
+        }                                                   \
     } while (0)

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -50,11 +50,11 @@ protected:
     static bool _show_colors;
 };
 
-#define log_debug(...) Log::log(Log::Level::DEBUG, __VA_ARGS__)
-#define log_info(...) Log::log(Log::Level::INFO, __VA_ARGS__)
-#define log_notice(...) Log::log(Log::Level::NOTICE, __VA_ARGS__)
+#define log_debug(...)   Log::log(Log::Level::DEBUG, __VA_ARGS__)
+#define log_info(...)    Log::log(Log::Level::INFO, __VA_ARGS__)
+#define log_notice(...)  Log::log(Log::Level::NOTICE, __VA_ARGS__)
 #define log_warning(...) Log::log(Log::Level::WARNING, __VA_ARGS__)
-#define log_error(...) Log::log(Log::Level::ERROR, __VA_ARGS__)
+#define log_error(...)   Log::log(Log::Level::ERROR, __VA_ARGS__)
 
 #define assert_or_return(exp, ...)                          \
     do {                                                    \

--- a/src/common/macro.h
+++ b/src/common/macro.h
@@ -17,13 +17,13 @@
  */
 #pragma once
 
-#define _must_check_ __attribute__((warn_unused_result))
+#define _must_check_          __attribute__((warn_unused_result))
 #define _printf_format_(a, b) __attribute__((format(printf, a, b)))
-#define _unused_ __attribute__((unused))
-#define _always_inline_ __inline__ __attribute__((always_inline))
-#define _cleanup_(x) __attribute__((cleanup(x)))
-#define _pure_ __attribute__((pure))
-#define _packed_ __attribute__((packed))
+#define _unused_              __attribute__((unused))
+#define _always_inline_       __inline__ __attribute__((always_inline))
+#define _cleanup_(x)          __attribute__((cleanup(x)))
+#define _pure_                __attribute__((pure))
+#define _packed_              __attribute__((packed))
 
 #define IOVEC_SET_STRING(i, s)    \
     do {                          \

--- a/src/common/macro.h
+++ b/src/common/macro.h
@@ -18,17 +18,17 @@
 #pragma once
 
 #define _must_check_ __attribute__((warn_unused_result))
-#define _printf_format_(a,b) __attribute__((format (printf, a, b)))
+#define _printf_format_(a, b) __attribute__((format(printf, a, b)))
 #define _unused_ __attribute__((unused))
 #define _always_inline_ __inline__ __attribute__((always_inline))
 #define _cleanup_(x) __attribute__((cleanup(x)))
 #define _pure_ __attribute__((pure))
 #define _packed_ __attribute__((packed))
 
-#define IOVEC_SET_STRING(i, s)          \
-    do {                                \
-        struct iovec *_i = &(i);        \
-        char *_s = (char *)(s);         \
-        _i->iov_base = _s;              \
-        _i->iov_len = strlen(_s);       \
-    } while(0)
+#define IOVEC_SET_STRING(i, s)    \
+    do {                          \
+        struct iovec *_i = &(i);  \
+        char *_s = (char *)(s);   \
+        _i->iov_base = _s;        \
+        _i->iov_len = strlen(_s); \
+    } while (0)

--- a/src/common/mavlink.h
+++ b/src/common/mavlink.h
@@ -14,7 +14,7 @@
  * you may be interested checking case by case in mavlink/pymavlink.
  */
 #if defined(HAVE_WADDRESS_OF_PACKED_MEMBER) && HAVE_WADDRESS_OF_PACKED_MEMBER
-#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#    pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 #endif
 #include <mavlink.h>
 #pragma GCC diagnostic pop

--- a/src/common/mavlink.h
+++ b/src/common/mavlink.h
@@ -18,4 +18,3 @@
 #endif
 #include <mavlink.h>
 #pragma GCC diagnostic pop
-

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -26,16 +26,13 @@
 
 usec_t ts_usec(const struct timespec *ts)
 {
-    if (ts->tv_sec == (time_t) -1 &&
-        ts->tv_nsec == (long) -1)
+    if (ts->tv_sec == (time_t)-1 && ts->tv_nsec == (long)-1)
         return USEC_INFINITY;
 
-    if ((usec_t) ts->tv_sec > (UINT64_MAX - (ts->tv_nsec / NSEC_PER_USEC)) / USEC_PER_SEC)
+    if ((usec_t)ts->tv_sec > (UINT64_MAX - (ts->tv_nsec / NSEC_PER_USEC)) / USEC_PER_SEC)
         return USEC_INFINITY;
 
-    return
-        (usec_t) ts->tv_sec * USEC_PER_SEC +
-        (usec_t) ts->tv_nsec / NSEC_PER_USEC;
+    return (usec_t)ts->tv_sec * USEC_PER_SEC + (usec_t)ts->tv_nsec / NSEC_PER_USEC;
 }
 
 usec_t now_usec(void)
@@ -99,10 +96,10 @@ int safe_atoi(const char *s, int *ret)
     if (!x || x == s || *x || errno)
         return errno > 0 ? -errno : -EINVAL;
 
-    if ((long) (int) l != l)
+    if ((long)(int)l != l)
         return -ERANGE;
 
-    *ret = (int) l;
+    *ret = (int)l;
     return 0;
 }
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -32,17 +32,17 @@ typedef uint64_t usec_t;
 typedef uint64_t nsec_t;
 #define USEC_INFINITY ((usec_t)-1)
 
-#define MSEC_PER_SEC 1000ULL
-#define USEC_PER_SEC ((usec_t)1000000ULL)
+#define MSEC_PER_SEC  1000ULL
+#define USEC_PER_SEC  ((usec_t)1000000ULL)
 #define USEC_PER_MSEC ((usec_t)1000ULL)
-#define NSEC_PER_SEC ((nsec_t)1000000000ULL)
+#define NSEC_PER_SEC  ((nsec_t)1000000000ULL)
 #define NSEC_PER_MSEC ((nsec_t)1000000ULL)
 #define NSEC_PER_USEC ((nsec_t)1000ULL)
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-#define streq(a, b) (strcmp((a), (b)) == 0)
-#define strcaseeq(a, b) (strcasecmp((a), (b)) == 0)
-#define strncaseeq(a, b, len) (strncasecmp((a), (b), (len)) == 0)
+#define ARRAY_SIZE(arr)               (sizeof(arr) / sizeof((arr)[0]))
+#define streq(a, b)                   (strcmp((a), (b)) == 0)
+#define strcaseeq(a, b)               (strcasecmp((a), (b)) == 0)
+#define strncaseeq(a, b, len)         (strncasecmp((a), (b), (len)) == 0)
 #define memcaseeq(a, len_a, b, len_b) ((len_a) == (len_b) && strncaseeq(a, b, len_a))
 
 int safe_atoull(const char *s, unsigned long long *ret);
@@ -57,14 +57,14 @@ int mkdir_p(const char *path, int len, mode_t mode);
 #endif
 
 #ifndef strndupa
-#define strndupa(s, n)                           \
-    (__extension__({                             \
-        const char *__in = (s);                  \
-        size_t __len = strnlen(__in, (n));       \
-        char *__out = (char *)alloca(__len + 1); \
-        __out[__len] = '\0';                     \
-        (char *)memcpy(__out, __in, __len);      \
-    }))
+#    define strndupa(s, n)                           \
+        (__extension__({                             \
+            const char *__in = (s);                  \
+            size_t __len = strnlen(__in, (n));       \
+            char *__out = (char *)alloca(__len + 1); \
+            __out[__len] = '\0';                     \
+            (char *)memcpy(__out, __in, __len);      \
+        }))
 
-#include <asm/ioctls.h>
+#    include <asm/ioctls.h>
 #endif

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #pragma once
 
 #include <fcntl.h>
@@ -31,17 +30,17 @@ extern "C" {
 
 typedef uint64_t usec_t;
 typedef uint64_t nsec_t;
-#define USEC_INFINITY ((usec_t) -1)
+#define USEC_INFINITY ((usec_t)-1)
 
-#define MSEC_PER_SEC  1000ULL
-#define USEC_PER_SEC  ((usec_t) 1000000ULL)
-#define USEC_PER_MSEC ((usec_t) 1000ULL)
-#define NSEC_PER_SEC  ((nsec_t) 1000000000ULL)
-#define NSEC_PER_MSEC ((nsec_t) 1000000ULL)
-#define NSEC_PER_USEC ((nsec_t) 1000ULL)
+#define MSEC_PER_SEC 1000ULL
+#define USEC_PER_SEC ((usec_t)1000000ULL)
+#define USEC_PER_MSEC ((usec_t)1000ULL)
+#define NSEC_PER_SEC ((nsec_t)1000000000ULL)
+#define NSEC_PER_MSEC ((nsec_t)1000000ULL)
+#define NSEC_PER_USEC ((nsec_t)1000ULL)
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-#define streq(a,b) (strcmp((a),(b)) == 0)
+#define streq(a, b) (strcmp((a), (b)) == 0)
 #define strcaseeq(a, b) (strcasecmp((a), (b)) == 0)
 #define strncaseeq(a, b, len) (strncasecmp((a), (b), (len)) == 0)
 #define memcaseeq(a, len_a, b, len_b) ((len_a) == (len_b) && strncaseeq(a, b, len_a))
@@ -58,12 +57,14 @@ int mkdir_p(const char *path, int len, mode_t mode);
 #endif
 
 #ifndef strndupa
-#define strndupa(s, n) \
-       (__extension__ ({const char *__in = (s); \
-                        size_t __len = strnlen (__in, (n)); \
-                        char *__out = (char *) alloca (__len + 1); \
-                        __out[__len] = '\0'; \
-                        (char *) memcpy (__out, __in, __len);}))
+#define strndupa(s, n)                           \
+    (__extension__({                             \
+        const char *__in = (s);                  \
+        size_t __len = strnlen(__in, (n));       \
+        char *__out = (char *)alloca(__len + 1); \
+        __out[__len] = '\0';                     \
+        (char *)memcpy(__out, __in, __len);      \
+    }))
 
 #include <asm/ioctls.h>
 #endif

--- a/src/common/xtermios.cpp
+++ b/src/common/xtermios.cpp
@@ -25,11 +25,12 @@ int reset_uart(int fd)
 {
     struct termios tc = {};
     /* See termios(3) */
-    const cc_t default_cc[] = { 03, 034, 0177, 025, 04, 0, 0, 0, 021, 023, 032, 0,
-                                022, 017, 027, 026, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                0, 0, 0, 0, 0, 0 };
+    const cc_t default_cc[]
+        = {03, 034, 0177, 025, 04, 0, 0, 0, 021, 023, 032, 0, 022, 017, 027, 026,
+           0,  0,   0,    0,   0,  0, 0, 0, 0,   0,   0,   0, 0,   0,   0,   0};
 
-    static_assert(sizeof(default_cc) == sizeof(tc.c_cc), "Unknown termios struct with different size");
+    static_assert(sizeof(default_cc) == sizeof(tc.c_cc),
+                  "Unknown termios struct with different size");
 
     if (tcgetattr(fd, &tc) < 0) {
         return -1;
@@ -39,7 +40,7 @@ int reset_uart(int fd)
     tc.c_cflag = CREAD;
 
     tc.c_iflag |= BRKINT | ICRNL | IMAXBEL;
-    tc.c_iflag &= ~(INLCR | IGNCR | IUTF8 | IXOFF| IUCLC | IXANY);
+    tc.c_iflag &= ~(INLCR | IGNCR | IUTF8 | IXOFF | IUCLC | IXANY);
 
     tc.c_oflag |= OPOST | ONLCR;
     tc.c_oflag &= ~(OLCUC | OCRNL | ONLRET | OFILL | OFDEL | NL0 | CR0 | TAB0 | BS0 | VT0 | FF0);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -135,11 +135,13 @@ int Endpoint::handle_read()
     int target_sysid, target_compid, r;
     uint8_t src_sysid, src_compid;
     uint32_t msg_id;
-    struct buffer buf{};
+    struct buffer buf {
+    };
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id)) > 0)
-        Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
-                                           src_compid, msg_id);
+    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id))
+           > 0)
+        Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid, src_compid,
+                                           msg_id);
 
     return r;
 }
@@ -387,9 +389,9 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
 
-    if (msg_id != UINT32_MAX &&
-        _message_filter.size() > 0 &&
-        std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
+    if (msg_id != UINT32_MAX && _message_filter.size() > 0
+        && std::find(_message_filter.begin(), _message_filter.end(), msg_id)
+            == _message_filter.end()) {
 
         // if filter is defined and message is not in the set then discard it
         return false;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -91,12 +91,14 @@ public:
 
     bool has_sys_id(unsigned sysid);
     bool has_sys_comp_id(unsigned sys_comp_id);
-    bool has_sys_comp_id(unsigned sysid, unsigned compid) {
+    bool has_sys_comp_id(unsigned sysid, unsigned compid)
+    {
         uint16_t sys_comp_id = ((sysid & 0xff) << 8) | (compid & 0xff);
         return has_sys_comp_id(sys_comp_id);
     }
 
-    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
+    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid,
+                    uint32_t msg_id);
 
     void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
 
@@ -140,7 +142,7 @@ private:
 class UartEndpoint : public Endpoint {
 public:
     UartEndpoint()
-        : Endpoint {"UART"}
+        : Endpoint{"UART"}
     {
     }
     virtual ~UartEndpoint();
@@ -178,7 +180,6 @@ public:
     struct sockaddr_in sockaddr;
     struct sockaddr_in6 sockaddr6;
 
-
     bool ipv6;
 
 protected:
@@ -205,13 +206,9 @@ public:
     bool ipv6;
     int retry_timeout = 0;
 
-    inline const char *get_ip() {
-        return _ip;
-    }
+    inline const char *get_ip() { return _ip; }
 
-    inline unsigned long get_port() {
-        return _port;
-    }
+    inline unsigned long get_port() { return _port; }
 
     bool is_valid() override { return _valid; };
     bool is_critical() override { return false; };

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -56,7 +56,7 @@ LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode,
     _fsync_cb.aio_fildes = -1;
 
 #if HAVE_DECL_AIO_INIT
-    aioinit aio_init_data {};
+    aioinit aio_init_data{};
     aio_init_data.aio_threads = 1;
     aio_init_data.aio_num = 1;
     aio_init_data.aio_idle_time = 3; // make sure to keep the thread running
@@ -119,7 +119,7 @@ void LogEndpoint::_delete_old_logs()
     struct statvfs buf;
     uint64_t free_space;
     if (statvfs(_logs_dir, &buf) == 0) {
-        free_space = (uint64_t) buf.f_bsize * buf.f_bavail;
+        free_space = (uint64_t)buf.f_bsize * buf.f_bavail;
     } else {
         free_space = UINT64_MAX;
         log_error("[Log Deletion] Error when measuring free disk space: %m");
@@ -327,8 +327,9 @@ void LogEndpoint::stop()
 
     // change file permissions to read-only to mark them as finished
     char log_file[PATH_MAX];
-    if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, _filename) < (int)sizeof(log_file)) {
-        chmod(log_file, S_IRUSR|S_IRGRP|S_IROTH);
+    if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, _filename)
+        < (int)sizeof(log_file)) {
+        chmod(log_file, S_IRUSR | S_IRGRP | S_IROTH);
     }
 }
 
@@ -420,14 +421,15 @@ bool LogEndpoint::_start_alive_timeout()
 }
 
 void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
-        uint8_t source_component_id, uint8_t *payload)
+                                          uint8_t source_component_id, uint8_t *payload)
 {
     if (_target_system_id == -1) { // wait until initialized
         return;
     }
     if (_mode == LogMode::always) {
         if (_file == -1) {
-            if (!start()) _mode = LogMode::disabled;
+            if (!start())
+                _mode = LogMode::disabled;
         }
     } else if (_mode == LogMode::while_armed) {
         if (msg_id == MAVLINK_MSG_ID_HEARTBEAT && source_system_id == _target_system_id
@@ -437,7 +439,8 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
             const bool is_armed = heartbeat->base_mode & MAV_MODE_FLAG_SAFETY_ARMED;
 
             if (_file == -1 && is_armed) {
-                if (!start()) _mode = LogMode::disabled;
+                if (!start())
+                    _mode = LogMode::disabled;
             } else if (_file != -1 && !is_armed) {
                 stop();
             }

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -41,7 +41,7 @@
 #include "mainloop.h"
 
 #define ALIVE_TIMEOUT 5
-#define MAX_RETRIES 10
+#define MAX_RETRIES   10
 
 LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode,
                          unsigned long min_free_space, unsigned long max_files)

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -26,14 +26,12 @@
 
 #define LOG_ENDPOINT_SYSTEM_ID 2
 
-
 enum class LogMode {
-    always = 0,         ///< Log from start until mavlink-router exits
-    while_armed,        ///< Start logging when the vehicle is armed until it's disarmed
+    always = 0,  ///< Log from start until mavlink-router exits
+    while_armed, ///< Start logging when the vehicle is armed until it's disarmed
 
-    disabled            ///< Do not try to start logging (only used internally)
+    disabled ///< Do not try to start logging (only used internally)
 };
-
 
 class LogEndpoint : public Endpoint {
 public:
@@ -78,7 +76,7 @@ protected:
     bool _fsync();
 
     void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
-            uint8_t source_component_id, uint8_t *payload);
+                                 uint8_t source_component_id, uint8_t *payload);
 
 private:
     int _get_file(const char *extension);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,10 +35,10 @@
 #include "endpoint.h"
 #include "mainloop.h"
 
-#define MAVLINK_TCP_PORT 5760
-#define DEFAULT_BAUDRATE 115200U
-#define DEFAULT_CONFFILE "/etc/mavlink-router/main.conf"
-#define DEFAULT_CONF_DIR "/etc/mavlink-router/config.d"
+#define MAVLINK_TCP_PORT          5760
+#define DEFAULT_BAUDRATE          115200U
+#define DEFAULT_CONFFILE          "/etc/mavlink-router/main.conf"
+#define DEFAULT_CONF_DIR          "/etc/mavlink-router/config.d"
 #define DEFAULT_RETRY_TCP_TIMEOUT 5
 
 extern const char *BUILD_VERSION;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,11 +20,11 @@
 #include <dirent.h>
 #include <getopt.h>
 #include <limits.h>
+#include <regex>
 #include <stddef.h>
 #include <stdio.h>
-#include <sys/stat.h>
 #include <string>
-#include <regex>
+#include <sys/stat.h>
 
 #include <common/conf_file.h>
 #include <common/dbg.h>
@@ -57,47 +57,47 @@ static struct options opt = {
     .max_log_files = 0,
 };
 
-static const struct option long_options[] = {
-    { "endpoints",              required_argument,  NULL,   'e' },
-    { "conf-file",              required_argument,  NULL,   'c' },
-    { "conf-dir" ,              required_argument,  NULL,   'd' },
-    { "report_msg_statistics",  no_argument,        NULL,   'r' },
-    { "tcp-port",               required_argument,  NULL,   't' },
-    { "tcp-endpoint",           required_argument,  NULL,   'p' },
-    { "log",                    required_argument,  NULL,   'l' },
-    { "debug-log-level",        required_argument,  NULL,   'g' },
-    { "verbose",                no_argument,        NULL,   'v' },
-    { "version",                no_argument,        NULL,   'V' },
-    { }
-};
+static const struct option long_options[] = {{"endpoints", required_argument, NULL, 'e'},
+                                             {"conf-file", required_argument, NULL, 'c'},
+                                             {"conf-dir", required_argument, NULL, 'd'},
+                                             {"report_msg_statistics", no_argument, NULL, 'r'},
+                                             {"tcp-port", required_argument, NULL, 't'},
+                                             {"tcp-endpoint", required_argument, NULL, 'p'},
+                                             {"log", required_argument, NULL, 'l'},
+                                             {"debug-log-level", required_argument, NULL, 'g'},
+                                             {"verbose", no_argument, NULL, 'v'},
+                                             {"version", no_argument, NULL, 'V'},
+                                             {}};
 
-static const char* short_options = "he:rt:c:d:l:p:g:vV";
+static const char *short_options = "he:rt:c:d:l:p:g:vV";
 
-static void help(FILE *fp) {
-    fprintf(fp,
-            "%s [OPTIONS...] [<uart>|<udp_address>]\n\n"
-            "  <uart>                       UART device (<device>[:<baudrate>]) that will be routed\n"
-            "  <udp_address>                UDP address (<ip>:<port>) that will be routed\n"
-            "  -e --endpoint <ip[:port]>    Add UDP endpoint to communicate port is optional\n"
-            "                               and in case it's not given it starts in 14550 and\n"
-            "                               continues increasing not to collide with previous\n"
-            "                               ports\n"
-            "  -p --tcp-endpoint <ip:port>  Add TCP endpoint client, which will connect to given\n"
-            "                               address\n"
-            "  -r --report_msg_statistics   Report message statistics\n"
-            "  -t --tcp-port <port>         Port in which mavlink-router will listen for TCP\n"
-            "                               connections. Pass 0 to disable TCP listening.\n"
-            "                               Default port 5760\n"
-            "  -c --conf-file <file>        .conf file with configurations for mavlink-router.\n"
-            "  -d --conf-dir <dir>          Directory where to look for .conf files overriding\n"
-            "                               default conf file.\n"
-            "  -l --log <directory>         Enable Flight Stack logging\n"
-            "  -g --debug-log-level <level> Set debug log level. Levels are\n"
-            "                               <error|warning|info|debug>\n"
-            "  -v --verbose                 Verbose. Same as --debug-log-level=debug\n"
-            "  -V --version                 Show version\n"
-            "  -h --help                    Print this message\n"
-            , program_invocation_short_name);
+static void help(FILE *fp)
+{
+    fprintf(
+        fp,
+        "%s [OPTIONS...] [<uart>|<udp_address>]\n\n"
+        "  <uart>                       UART device (<device>[:<baudrate>]) that will be routed\n"
+        "  <udp_address>                UDP address (<ip>:<port>) that will be routed\n"
+        "  -e --endpoint <ip[:port]>    Add UDP endpoint to communicate port is optional\n"
+        "                               and in case it's not given it starts in 14550 and\n"
+        "                               continues increasing not to collide with previous\n"
+        "                               ports\n"
+        "  -p --tcp-endpoint <ip:port>  Add TCP endpoint client, which will connect to given\n"
+        "                               address\n"
+        "  -r --report_msg_statistics   Report message statistics\n"
+        "  -t --tcp-port <port>         Port in which mavlink-router will listen for TCP\n"
+        "                               connections. Pass 0 to disable TCP listening.\n"
+        "                               Default port 5760\n"
+        "  -c --conf-file <file>        .conf file with configurations for mavlink-router.\n"
+        "  -d --conf-dir <dir>          Directory where to look for .conf files overriding\n"
+        "                               default conf file.\n"
+        "  -l --log <directory>         Enable Flight Stack logging\n"
+        "  -g --debug-log-level <level> Set debug log level. Levels are\n"
+        "                               <error|warning|info|debug>\n"
+        "  -v --verbose                 Verbose. Same as --debug-log-level=debug\n"
+        "  -V --version                 Show version\n"
+        "  -h --help                    Print this message\n",
+        program_invocation_short_name);
 }
 
 static unsigned long find_next_endpoint_port(const char *ip)
@@ -152,7 +152,7 @@ static bool validate_ipv4(const char *ip)
     return regex_match(ip, ipv4_regex);
 }
 
-static bool validate_ip(const char* ip)
+static bool validate_ip(const char *ip)
 {
     return validate_ipv4(ip) || validate_ipv6(ip);
 }
@@ -292,10 +292,8 @@ fail:
     return ret;
 }
 
-static std::vector<unsigned long> *strlist_to_ul(const char *list,
-                                                 const char *listname,
-                                                 const char *delim,
-                                                 unsigned long default_value)
+static std::vector<unsigned long> *strlist_to_ul(const char *list, const char *listname,
+                                                 const char *delim, unsigned long default_value)
 {
     char *s, *tmp_str;
     std::unique_ptr<std::vector<unsigned long>> v{new std::vector<unsigned long>()};
@@ -658,7 +656,6 @@ static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t
 }
 #undef MAX_LOG_MODE_SIZE
 
-
 static int parse_mode(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
     assert(val);
@@ -715,9 +712,10 @@ static int parse_confs(ConfFile &conf)
         bool flowcontrol;
     };
     static const ConfFile::OptionsTable option_table_uart[] = {
-        {"baud",        false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_uart, bauds)},
-        {"device",      true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_uart, device)},
-        {"FlowControl", false,  ConfFile::parse_bool,       OPTIONS_TABLE_STRUCT_FIELD(option_uart, flowcontrol)},
+        {"baud", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_uart, bauds)},
+        {"device", true, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_uart, device)},
+        {"FlowControl", false, ConfFile::parse_bool,
+         OPTIONS_TABLE_STRUCT_FIELD(option_uart, flowcontrol)},
     };
 
     struct option_udp {
@@ -727,10 +725,10 @@ static int parse_confs(ConfFile &conf)
         char *filter;
     };
     static const ConfFile::OptionsTable option_table_udp[] = {
-        {"address", true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
-        {"mode",    true,   parse_mode,                 OPTIONS_TABLE_STRUCT_FIELD(option_udp, server)},
-        {"port",    false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
-        {"filter",  false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
+        {"address", true, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
+        {"mode", true, parse_mode, OPTIONS_TABLE_STRUCT_FIELD(option_udp, server)},
+        {"port", false, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
+        {"filter", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
     };
 
     struct option_tcp {
@@ -739,9 +737,9 @@ static int parse_confs(ConfFile &conf)
         int timeout;
     };
     static const ConfFile::OptionsTable option_table_tcp[] = {
-        {"address",         true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_tcp, addr)},
-        {"port",            true,   ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_tcp, port)},
-        {"RetryTimeout",    false,  ConfFile::parse_i,          OPTIONS_TABLE_STRUCT_FIELD(option_tcp, timeout)},
+        {"address", true, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_tcp, addr)},
+        {"port", true, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(option_tcp, port)},
+        {"RetryTimeout", false, ConfFile::parse_i, OPTIONS_TABLE_STRUCT_FIELD(option_tcp, timeout)},
     };
 
     ret = conf.extract_options("General", option_table, ARRAY_SIZE(option_table), &opt);
@@ -776,11 +774,13 @@ static int parse_confs(ConfFile &conf)
                 ret = -EINVAL;
             } else {
                 if (!validate_ip(opt_udp.addr)) {
-                    log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name, opt_udp.addr);
+                    log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len,
+                              iter.name, opt_udp.addr);
                     ret = -EINVAL;
                 } else {
-                    ret = add_endpoint_address(iter.name + offset, iter.name_len - offset, opt_udp.addr,
-                                               opt_udp.port, opt_udp.server, opt_udp.filter);
+                    ret = add_endpoint_address(iter.name + offset, iter.name_len - offset,
+                                               opt_udp.addr, opt_udp.port, opt_udp.server,
+                                               opt_udp.filter);
                 }
             }
         }
@@ -799,11 +799,12 @@ static int parse_confs(ConfFile &conf)
 
         if (ret == 0) {
             if (!validate_ip(opt_tcp.addr)) {
-                log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name, opt_tcp.addr);
+                log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name,
+                          opt_tcp.addr);
                 ret = -EINVAL;
             } else {
-                ret = add_tcp_endpoint_address(iter.name + offset, iter.name_len - offset, opt_tcp.addr,
-                                               opt_tcp.port, opt_tcp.timeout);
+                ret = add_tcp_endpoint_address(iter.name + offset, iter.name_len - offset,
+                                               opt_tcp.addr, opt_tcp.port, opt_tcp.timeout);
             }
         }
         free(opt_tcp.addr);
@@ -910,7 +911,7 @@ int main(int argc, char *argv[])
     if (parse_argv(argc, argv) != 2)
         goto close_log;
 
-    Log::set_max_level((Log::Level) opt.debug_log_level);
+    Log::set_max_level((Log::Level)opt.debug_log_level);
 
     dbg("Cmd line and options parsed");
 

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -31,7 +31,7 @@
 
 #include "autolog.h"
 
-static std::atomic<bool> should_exit {false};
+static std::atomic<bool> should_exit{false};
 
 Mainloop Mainloop::_instance{};
 bool Mainloop::_initialized = false;
@@ -43,7 +43,7 @@ static void exit_signal_handler(int signum)
 
 static void setup_signal_handlers()
 {
-    struct sigaction sa = { };
+    struct sigaction sa = {};
 
     sa.sa_flags = SA_NOCLDSTOP;
     sa.sa_handler = exit_signal_handler;
@@ -96,7 +96,7 @@ int Mainloop::open()
 
 int Mainloop::mod_fd(int fd, void *data, int events)
 {
-    struct epoll_event epev = { };
+    struct epoll_event epev = {};
 
     epev.events = events;
     epev.data.ptr = data;
@@ -111,7 +111,7 @@ int Mainloop::mod_fd(int fd, void *data, int events)
 
 int Mainloop::add_fd(int fd, void *data, int events)
 {
-    struct epoll_event epev = { };
+    struct epoll_event epev = {};
 
     epev.events = events;
     epev.data.ptr = data;
@@ -155,17 +155,18 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 
     for (Endpoint **e = g_endpoints; *e != nullptr; e++) {
         if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
-            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", (*e)->fd, msg_id, target_sysid,
-                      target_compid, sender_sysid, sender_compid);
+            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", (*e)->fd, msg_id,
+                      target_sysid, target_compid, sender_sysid, sender_compid);
             write_msg(*e, buf);
             unknown = false;
         }
     }
 
     for (struct endpoint_entry *e = g_tcp_endpoints; e; e = e->next) {
-        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
-            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->endpoint->fd, msg_id,
-                      target_sysid, target_compid, sender_sysid, sender_compid);
+        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid,
+                                    msg_id)) {
+            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->endpoint->fd,
+                      msg_id, target_sysid, target_compid, sender_sysid, sender_compid);
             int r = write_msg(e->endpoint, buf);
             if (r == -EPIPE) {
                 should_process_tcp_hangups = true;
@@ -392,7 +393,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
     if (opt->logs_dir)
         n_endpoints++;
 
-    g_endpoints = (Endpoint**) calloc(n_endpoints + 1, sizeof(Endpoint*));
+    g_endpoints = (Endpoint **)calloc(n_endpoints + 1, sizeof(Endpoint *));
     assert_or_return(g_endpoints, false);
 
     for (conf = opt->endpoints; conf; conf = conf->next) {
@@ -432,7 +433,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                 while (token != NULL) {
                     udp->add_message_to_filter(atoi(token));
                     token = strtok(NULL, ",");
-                } 
+                }
             }
 
             g_endpoints[i] = udp.release();
@@ -519,7 +520,7 @@ void Mainloop::free_endpoints(struct options *opt)
 int Mainloop::tcp_open(unsigned long tcp_port)
 {
     int fd;
-    struct sockaddr_in sockaddr = { };
+    struct sockaddr_in sockaddr = {};
     int val = 1;
 
     fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
@@ -553,7 +554,8 @@ int Mainloop::tcp_open(unsigned long tcp_port)
     return fd;
 }
 
-Timeout *Mainloop::add_timeout(uint32_t timeout_msec, std::function<bool(void*)> cb, const void *data)
+Timeout *Mainloop::add_timeout(uint32_t timeout_msec, std::function<bool(void *)> cb,
+                               const void *data)
 {
     struct itimerspec ts;
     Timeout *t = new Timeout(cb, data);
@@ -620,20 +622,19 @@ void Mainloop::_del_timeouts()
 
 void Mainloop::_add_tcp_retry(TcpEndpoint *tcp)
 {
-    Timeout *t
-        ;
+    Timeout *t;
     if (tcp->retry_timeout <= 0) {
         return;
     }
 
     tcp->close();
     t = add_timeout(MSEC_PER_SEC * tcp->retry_timeout,
-            std::bind(&Mainloop::_retry_timeout_cb, this, std::placeholders::_1),
-            tcp);
+                    std::bind(&Mainloop::_retry_timeout_cb, this, std::placeholders::_1), tcp);
 
     if (t == nullptr) {
         log_warning("Could not create retry timeout for TCP endpoint %s:%lu\n"
-                    "No attempts to reconnect will be made", tcp->get_ip(), tcp->get_port());
+                    "No attempts to reconnect will be made",
+                    tcp->get_ip(), tcp->get_port());
     }
 }
 

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -42,7 +42,7 @@ public:
     void handle_tcp_connection();
     int write_msg(Endpoint *e, const struct buffer *buf);
     void process_tcp_hangups();
-    Timeout *add_timeout(uint32_t timeout_msec, std::function<bool(void*)> cb, const void *data);
+    Timeout *add_timeout(uint32_t timeout_msec, std::function<bool(void *)> cb, const void *data);
     void del_timeout(Timeout *t);
 
     void free_endpoints(struct options *opt);
@@ -74,7 +74,6 @@ public:
      * Request that loop exits on next iteration.
      */
     void request_exit(int retcode);
-
 
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;

--- a/src/mainloop_test.cpp
+++ b/src/mainloop_test.cpp
@@ -2,16 +2,18 @@
 
 #include <gtest/gtest.h>
 
-TEST(MainLoopTest, termination) {
-    Mainloop& mainloop = Mainloop::init();
+TEST(MainLoopTest, termination)
+{
+    Mainloop &mainloop = Mainloop::init();
     mainloop.open();
     mainloop.request_exit(0);
     int ret = mainloop.loop();
     EXPECT_EQ(0, ret);
 }
 
-TEST(MainLoopTest, wrong_termination) {
-    Mainloop& mainloop = Mainloop::init();
+TEST(MainLoopTest, wrong_termination)
+{
+    Mainloop &mainloop = Mainloop::init();
     mainloop.open();
     mainloop.request_exit(-1);
     int ret = mainloop.loop();

--- a/src/timeout.cpp
+++ b/src/timeout.cpp
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
-Timeout::Timeout(std::function<bool(void*)> cb, const void *data)
+Timeout::Timeout(std::function<bool(void *)> cb, const void *data)
 {
     assert(cb);
     _cb = cb;

--- a/src/timeout.h
+++ b/src/timeout.h
@@ -23,7 +23,7 @@
 
 class Timeout : public Pollable {
 public:
-    Timeout(std::function<bool(void*)> cb, const void *data);
+    Timeout(std::function<bool(void *)> cb, const void *data);
     bool remove_me = false;
     Timeout *next = nullptr;
 
@@ -31,6 +31,6 @@ public:
     bool handle_canwrite() override;
 
 private:
-    std::function<bool(void*)> _cb;
+    std::function<bool(void *)> _cb;
     const void *_data;
 };

--- a/src/ulog.cpp
+++ b/src/ulog.cpp
@@ -109,7 +109,6 @@ int ULog::write_msg(const struct buffer *buffer)
     uint8_t source_system_id;
     uint8_t source_component_id;
 
-
     if (mavlink2) {
         struct mavlink_router_mavlink2_header *msg
             = (struct mavlink_router_mavlink2_header *)buffer->data;

--- a/src/ulog.h
+++ b/src/ulog.h
@@ -39,6 +39,7 @@ protected:
     bool _logging_start_timeout() override;
 
     const char *_get_logfile_extension() override { return "ulg"; };
+
 private:
     uint16_t _expected_seq = 0;
     bool _waiting_header = true;


### PR DESCRIPTION
This PR introduces a few new settings in the clang-format file, some of those need at least clang-format 9:
- AlignConsecutiveDeclarations, AlignConsecutiveAssignments, AlignConsecutiveMacros: Specify as already used in most of the files, **even though I would like to enable all of them**.
- IndentPPDirectives: Was used this way in some files, and not in others -> **TBD**
- FixNamespaceComments: Enabling this is always a good idea to keep things in sync.

Please add your comments, whether consecutive assignments and declarations should also be aligned and how to set the indentation of preprocessor directives (nested #ifdef).
```cpp
# AlignConsecutiveDeclarations off
int foo = 5;
double foobar = 7;

# AlignConsecutiveDeclarations on
int    foo    = 5;
double foobar = 7;
```

All files were formatted again with clang-format 13. Most of the changes do not result from the changes made to the configuration, but just apply the existing rules.

**Notes on compatibility**:  
AlignConsecutiveMacros was introduced in clang-format 9 (but I really like it), IndentPPDirectives in version 6. Debian stable (bullseye) comes with version 11, old stable (buster) might be an issue using clang 7 by default. Ubuntu is fine from version 20.04 (focal) and newer, but 18.04 (bionic) seems to have clang-format-9 as well, just as a separate package.