### PR TITLE
build: set to buildoptimized by default like previously

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ A typical configuration for a x86-64 system is shown below:
     $ meson setup build .
 
 By default systemd integration is enabled. In a system without systemd you should
-pass the servie directory with -Dsystemdsystemunitdir=/usr/lib/systemd/system
+pass the service directory with `-Dsystemdsystemunitdir=/usr/lib/systemd/system`
+By default the build type is settled to "debugoptimized". It can be changed with
+`--buildtype=release`, see [Meson documentation](https://mesonbuild.com/Builtin-options.html#core-options) for more options
 
 Installation location can be changed using the -Dprefix option to `meson setup`.
 

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project(
                 'cpp_std=gnu++11',
                 'prefix=/usr',
                 'warning_level=2',
+                'buildtype=debugoptimized',
         ],
         meson_version : '>= 0.57',
 )


### PR DESCRIPTION
On a side note, the readme should said to install meson with pip on Ubuntu, as the latest release on 21.04 for meson is Version: 0.57.0+really0.56.2-0.1 . So that doesn't pass the meson version requirement.