### PR TITLE
Meson: lower meson version requirement to 0.55

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
                 'prefix=/usr',
                 'warning_level=2',
         ],
-        meson_version : '>= 0.57',
+        meson_version : '>= 0.55',
 )
 
 project_source_root = meson.current_source_dir()


### PR DESCRIPTION
As discuss there : https://github.com/mavlink-router/mavlink-router/pull/297