### PR TITLE
Rework the internal flow of the config options

### DIFF
--- a/src/autolog.cpp
+++ b/src/autolog.cpp
@@ -63,11 +63,9 @@ int AutoLog::write_msg(const struct buffer *buffer)
     /* We check autopilot on heartbeat */
     log_debug("Got autopilot %u from heartbeat", heartbeat->autopilot);
     if (heartbeat->autopilot == MAV_AUTOPILOT_PX4) {
-        _logger
-            = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode, _min_free_space, _max_files));
+        _logger = std::unique_ptr<LogEndpoint>(new ULog(_config));
     } else if (heartbeat->autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        _logger = std::unique_ptr<LogEndpoint>(
-            new BinLog(_logs_dir, _mode, _min_free_space, _max_files));
+        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_config));
     } else {
         log_warning("Unidentified autopilot, cannot start flight stack logging");
     }

--- a/src/autolog.h
+++ b/src/autolog.h
@@ -24,9 +24,8 @@
 
 class AutoLog : public LogEndpoint {
 public:
-    AutoLog(const char *logs_dir, LogMode mode, unsigned long min_free_space,
-            unsigned long max_files)
-        : LogEndpoint{"AutoLog", logs_dir, mode, min_free_space, max_files}
+    AutoLog(LogOptions conf)
+        : LogEndpoint{"AutoLog", conf}
     {
     }
 

--- a/src/binlog.h
+++ b/src/binlog.h
@@ -24,9 +24,8 @@
 
 class BinLog : public LogEndpoint {
 public:
-    BinLog(const char *logs_dir, LogMode mode, unsigned long min_free_space,
-           unsigned long max_files)
-        : LogEndpoint{"BinLog", logs_dir, mode, min_free_space, max_files}
+    BinLog(LogOptions conf)
+        : LogEndpoint{"BinLog", conf}
     {
     }
 

--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -23,6 +23,7 @@
 #include <fnmatch.h>
 #include <limits.h>
 #include <string.h>
+#include <string>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -61,21 +62,19 @@ ConfFile::~ConfFile()
     release_all();
 }
 
-int ConfFile::parse(const char *filename)
+int ConfFile::parse(const std::string &filename)
 {
     int fd, ret = 0;
     void *addr;
     struct stat fstat;
 
-    assert(filename);
-
-    fd = open(filename, O_RDONLY | O_CLOEXEC);
+    fd = open(filename.c_str(), O_RDONLY | O_CLOEXEC);
     if (fd < 0) {
-        log_error("Could not open conf file '%s' (%m)", filename);
+        log_error("Could not open conf file '%s' (%m)", filename.c_str());
         return -errno;
     }
 
-    if (stat(filename, &fstat) < 0) {
+    if (stat(filename.c_str(), &fstat) < 0) {
         ret = -errno;
         goto error;
     }
@@ -88,7 +87,7 @@ int ConfFile::parse(const char *filename)
 
     close(fd);
 
-    _files = new conffile{addr, (size_t)fstat.st_size, strdup(filename), _files};
+    _files = new conffile{addr, (size_t)fstat.st_size, strdup(filename.c_str()), _files};
 
     ret = _parse_file((char *)addr, (size_t)fstat.st_size, _files->filename);
     if (ret < 0) {
@@ -489,6 +488,22 @@ int ConfFile::parse_str_buf(const char *val, size_t val_len, void *storage, size
     memcpy(storage, val, val_len);
     ((char *)storage)[val_len] = '\0';
 
+    return 0;
+}
+
+int ConfFile::parse_stdstring(const char *val, size_t val_len, void *storage, size_t storage_len)
+{
+    auto *ptr = (std::string *)storage;
+
+    assert(val);
+    assert(storage);
+    assert(val_len);
+
+    if (storage_len < sizeof(char *)) {
+        return -ENOBUFS;
+    }
+
+    ptr->assign(val, val_len);
     return 0;
 }
 

--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -507,6 +507,28 @@ int ConfFile::parse_stdstring(const char *val, size_t val_len, void *storage, si
     return 0;
 }
 
+int ConfFile::parse_uint8_vector(const char *val, size_t val_len, void *storage, size_t storage_len)
+{
+    assert(val);
+    assert(storage);
+    assert(val_len);
+
+    if (storage_len < sizeof(bool)) {
+        return -ENOBUFS;
+    }
+
+    char *filter_string = strndupa(val, val_len);
+    auto *target = (std::vector<uint8_t> *)storage;
+
+    char *token = strtok(filter_string, ",");
+    while (token != nullptr) {
+        target->push_back(atoi(token));
+        token = strtok(nullptr, ",");
+    }
+
+    return 0;
+}
+
 int ConfFile::parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
     bool *b = (bool *)storage;

--- a/src/common/conf_file.h
+++ b/src/common/conf_file.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include <string>
+
 /**
  * Load and parse multiple conf files, offering methods to extract the configuration options to user
  * structs.
@@ -66,7 +68,7 @@ public:
      * @param filename The conf filename
      * @return errno on IO or parsing errors or @c 0 if successful
      */
-    int parse(const char *filename);
+    int parse(const std::string &filename);
 
     /**
      * Release all opened files and internal structures from this ConfFile.
@@ -119,8 +121,8 @@ public:
     // Helpers
     static int parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_dup(const char *val, size_t val_len, void *storage, size_t storage_len);
-    static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_buf(const char *val, size_t val_len, void *storage, size_t storage_len);
+    static int parse_stdstring(const char *val, size_t val_len, void *storage, size_t storage_len);
 
 #define DECLARE_PARSE_INT(_type) \
     static int parse_##_type(const char *val, size_t val_len, void *storage, size_t storage_len)
@@ -135,14 +137,14 @@ private:
 
     int _parse_file(const char *addr, size_t len, const char *filename);
     struct section *_find_section(const char *section_name, size_t len);
-    struct config *_find_config(struct section *s, const char *key_name, size_t key_len);
+    static struct config *_find_config(struct section *s, const char *key_name, size_t key_len);
 
     struct section *_add_section(const char *addr, size_t len, int line, const char *filename);
-    int _add_config(struct section *s, const char *entry, size_t entry_len, const char *filename,
-                    int line);
-    void _trim(const char **str, size_t *len);
-    int _extract_options_from_section(struct section *s, const OptionsTable table[],
-                                      size_t table_len, void *data);
+    static int _add_config(struct section *s, const char *entry, size_t entry_len,
+                           const char *filename, int line);
+    static void _trim(const char **str, size_t *len);
+    static int _extract_options_from_section(struct section *s, const OptionsTable table[],
+                                             size_t table_len, void *data);
 };
 
 /*

--- a/src/common/conf_file.h
+++ b/src/common/conf_file.h
@@ -123,6 +123,8 @@ public:
     static int parse_str_dup(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_buf(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_stdstring(const char *val, size_t val_len, void *storage, size_t storage_len);
+    static int parse_uint8_vector(const char *val, size_t val_len, void *storage,
+                                  size_t storage_len);
 
 #define DECLARE_PARSE_INT(_type) \
     static int parse_##_type(const char *val, size_t val_len, void *storage, size_t storage_len)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -775,8 +775,6 @@ int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, bool server)
         sockaddr6.sin6_scope_id = ipv6_get_scope_id(ip_str);
     }
 
-    free(ip_str);
-
     if (server) {
         if (bind(fd, (struct sockaddr *)&sockaddr6, sizeof(sockaddr6)) < 0) {
             log_error("Error binding IPv6 socket (%m)");
@@ -785,6 +783,7 @@ int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, bool server)
         sockaddr6.sin6_port = 0;
     }
 
+    free(ip_str);
     return fd;
 
 fail:

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -353,9 +353,9 @@ void Endpoint::_add_sys_comp_id(uint16_t sys_comp_id)
     _sys_comp_ids.push_back(sys_comp_id);
 }
 
-bool Endpoint::has_sys_id(unsigned sysid)
+bool Endpoint::has_sys_id(unsigned sysid) const
 {
-    for (auto &id : _sys_comp_ids) {
+    for (const auto &id : _sys_comp_ids) {
         if (((id >> 8) | (sysid & 0xff)) == sysid) {
             return true;
         }
@@ -363,9 +363,9 @@ bool Endpoint::has_sys_id(unsigned sysid)
     return false;
 }
 
-bool Endpoint::has_sys_comp_id(unsigned sys_comp_id)
+bool Endpoint::has_sys_comp_id(unsigned sys_comp_id) const
 {
-    for (auto &id : _sys_comp_ids) {
+    for (const auto &id : _sys_comp_ids) {
         if (sys_comp_id == id) {
             return true;
         }
@@ -375,13 +375,13 @@ bool Endpoint::has_sys_comp_id(unsigned sys_comp_id)
 }
 
 Endpoint::AcceptState Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid,
-                                           uint8_t src_compid, uint32_t msg_id)
+                                           uint8_t src_compid, uint32_t msg_id) const
 {
     if (Log::get_max_level() >= Log::Level::DEBUG) {
         log_debug("Endpoint [%d]%s: got message %u to %d/%d from %u/%u", fd, _name.c_str(), msg_id,
                   target_sysid, target_compid, src_sysid, src_compid);
         log_debug("\tKnown components:");
-        for (auto &id : _sys_comp_ids) {
+        for (const auto &id : _sys_comp_ids) {
             log_debug("\t\t%u/%u", (id >> 8), id & 0xff);
         }
     }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -745,7 +745,7 @@ int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, bool server)
 {
     fd = socket(AF_INET6, SOCK_DGRAM, 0);
     if (fd < 0) {
-        log_error("Could not create socket (%m)");
+        log_error("Could not create IPv6 socket (%m)");
         return -errno;
     }
 
@@ -798,7 +798,7 @@ int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, bool server)
 {
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
-        log_error("Could not create socket (%m)");
+        log_error("Could not create IPv4 socket (%m)");
         return -errno;
     }
 
@@ -808,7 +808,7 @@ int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, bool server)
 
     if (server) {
         if (bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) < 0) {
-            log_error("Error binding socket (%m)");
+            log_error("Error binding IPv4 socket (%m)");
             goto fail;
         }
         sockaddr.sin_port = 0;
@@ -988,7 +988,7 @@ int TcpEndpoint::open_ipv6(const char *ip, unsigned long port)
 {
     fd = socket(AF_INET6, SOCK_STREAM, 0);
     if (fd == -1) {
-        log_error("Could not create socket (%m)");
+        log_error("Could not create IPv6 socket (%m)");
         return -1;
     }
 
@@ -1025,7 +1025,7 @@ int TcpEndpoint::open_ipv4(const char *ip, unsigned long port)
 {
     fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1) {
-        log_error("Could not create socket (%m)");
+        log_error("Could not create IPv4 socket (%m)");
         return -1;
     }
 
@@ -1068,7 +1068,7 @@ int TcpEndpoint::open(const char *ip, unsigned long port)
 
     // common setup
     if (connect(fd, sock, addrlen) < 0) {
-        log_error("Error connecting to IPv6 socket (%m)");
+        log_error("Error connecting to socket (%m)");
         goto fail;
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -652,7 +652,7 @@ bool UartEndpoint::_change_baud_cb(void *data)
 {
     _current_baud_idx = (_current_baud_idx + 1) % _baudrates.size();
 
-    log_info("Retrying UART [%d] on new baudrate: %lu", fd, _baudrates[_current_baud_idx]);
+    log_info("Retrying UART [%d] on new baudrate: %u", fd, _baudrates[_current_baud_idx]);
 
     set_speed(_baudrates[_current_baud_idx]);
 
@@ -665,7 +665,7 @@ int UartEndpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_c
     int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid, msg_id);
 
     if (_change_baud_timeout != nullptr && ret == ReadOk) {
-        log_info("Baudrate %lu responded, keeping it", _baudrates[_current_baud_idx]);
+        log_info("Baudrate %u responded, keeping it", _baudrates[_current_baud_idx]);
         Mainloop::get_instance().del_timeout(_change_baud_timeout);
         _change_baud_timeout = nullptr;
     }
@@ -717,7 +717,7 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
     return r;
 }
 
-int UartEndpoint::add_speeds(std::vector<unsigned long> bauds)
+int UartEndpoint::add_speeds(const std::vector<speed_t> &bauds)
 {
     if (bauds.empty()) {
         return -EINVAL;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <common/conf_file.h>
 #include <common/mavlink.h>
 
 #include <memory>
@@ -27,6 +28,8 @@
 #include "comm.h"
 #include "pollable.h"
 #include "timeout.h"
+
+#define DEFAULT_BAUDRATE 115200U
 
 #define ENDPOINT_TYPE_UART "UART"
 #define ENDPOINT_TYPE_UDP  "UDP"
@@ -198,6 +201,11 @@ public:
     int set_flow_control(bool enabled);
     int add_speeds(const std::vector<speed_t> &bauds);
 
+    static const ConfFile::OptionsTable option_table[4];
+    static const char *section_pattern;
+    static int parse_baudrates(const char *val, size_t val_len, void *storage, size_t storage_len);
+    static bool validate_config(const UartEndpointConfig &config);
+
 protected:
     int read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid, uint8_t *src_sysid,
                  uint8_t *src_compid, uint32_t *msg_id) override;
@@ -226,6 +234,11 @@ public:
     struct sockaddr_in6 sockaddr6;
 
     bool ipv6;
+
+    static const ConfFile::OptionsTable option_table[5];
+    static const char *section_pattern;
+    static int parse_udp_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
+    static bool validate_config(const UdpEndpointConfig &config);
 
 protected:
     int open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode);
@@ -257,6 +270,10 @@ public:
 
     bool is_valid() override { return _valid; };
     bool is_critical() override { return false; };
+
+    static const ConfFile::OptionsTable option_table[4];
+    static const char *section_pattern;
+    static bool validate_config(const TcpEndpointConfig &config);
 
 protected:
     int open_ipv4(const char *ip, unsigned long port);

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -219,7 +219,8 @@ public:
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
-    int open(const char *ip, unsigned long port, bool server = false);
+    int open(const char *ip, unsigned long port,
+             UdpEndpointConfig::Mode mode = UdpEndpointConfig::Mode::Client);
 
     struct sockaddr_in sockaddr;
     struct sockaddr_in6 sockaddr6;
@@ -227,8 +228,8 @@ public:
     bool ipv6;
 
 protected:
-    int open_ipv4(const char *ip, unsigned long port, bool server);
-    int open_ipv6(const char *ip, unsigned long port, bool server);
+    int open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode);
+    int open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 };

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -130,18 +130,20 @@ public:
     static uint8_t get_trimmed_zeros(const mavlink_msg_entry_t *msg_entry,
                                      const struct buffer *buffer);
 
-    bool has_sys_id(unsigned sysid);
-    bool has_sys_comp_id(unsigned sys_comp_id);
-    bool has_sys_comp_id(unsigned sysid, unsigned compid)
+    bool has_sys_id(unsigned sysid) const;
+    bool has_sys_comp_id(unsigned sys_comp_id) const;
+    bool has_sys_comp_id(unsigned sysid, unsigned compid) const
     {
         uint16_t sys_comp_id = ((sysid & 0xff) << 8) | (compid & 0xff);
         return has_sys_comp_id(sys_comp_id);
     }
 
     AcceptState accept_msg(int target_sysid, int target_compid, uint8_t src_sysid,
-                           uint8_t src_compid, uint32_t msg_id);
+                           uint8_t src_compid, uint32_t msg_id) const;
 
     void filter_add_allowed_msg_id(uint32_t msg_id) { _allowed_msg_ids.push_back(msg_id); }
+
+    std::string get_type() const { return this->_type; }
 
     struct buffer rx_buf;
     struct buffer tx_buf;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -276,10 +276,13 @@ public:
 
 protected:
     bool open(const std::string &ip, unsigned long port);
-    int open_ipv4(const char *ip, unsigned long port);
-    int open_ipv6(const char *ip, unsigned long port);
+    static int open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr);
+    static int open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
+
+    void _schedule_reconnect();
+    bool _retry_timeout_cb(void *data);
 
 private:
     std::string _ip{};

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <common/log.h>
@@ -43,9 +44,9 @@
 #define ALIVE_TIMEOUT 5
 #define MAX_RETRIES   10
 
-LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode,
+LogEndpoint::LogEndpoint(std::string name, const char *logs_dir, LogMode mode,
                          unsigned long min_free_space, unsigned long max_files)
-    : Endpoint{name}
+    : Endpoint{ENDPOINT_TYPE_LOG, std::move(name)}
     , _logs_dir{logs_dir}
     , _min_free_space(min_free_space)
     , _max_files(max_files)

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -46,7 +46,7 @@ struct LogOptions {
 
 class LogEndpoint : public Endpoint {
 public:
-    LogEndpoint(const char *name, const char *logs_dir, LogMode mode, unsigned long min_free_space,
+    LogEndpoint(std::string name, const char *logs_dir, LogMode mode, unsigned long min_free_space,
                 unsigned long max_files);
 
     virtual bool start();

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -48,8 +48,7 @@ struct LogOptions {
 
 class LogEndpoint : public Endpoint {
 public:
-    LogEndpoint(std::string name, const char *logs_dir, LogMode mode, unsigned long min_free_space,
-                unsigned long max_files);
+    LogEndpoint(std::string name, LogOptions conf);
 
     virtual bool start();
     virtual void stop();
@@ -67,12 +66,9 @@ public:
     static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
 
 protected:
-    const char *_logs_dir;
+    LogOptions _config;
     int _target_system_id = -1;
     int _file = -1;
-    unsigned long _min_free_space;
-    unsigned long _max_files;
-    LogMode _mode;
 
     struct {
         Timeout *logging_start = nullptr;

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -20,6 +20,7 @@
 #include <aio.h>
 #include <assert.h>
 #include <dirent.h>
+#include <string>
 
 #include "endpoint.h"
 #include "timeout.h"
@@ -31,6 +32,16 @@ enum class LogMode {
     while_armed, ///< Start logging when the vehicle is armed until it's disarmed
 
     disabled ///< Do not try to start logging (only used internally)
+};
+
+struct LogOptions {
+    enum class MavDialect { Auto, Common, Ardupilotmega };
+
+    std::string logs_dir;                         // conf "Log" or CLI "log"
+    LogMode log_mode{LogMode::always};            // conf "LogMode"
+    MavDialect mavlink_dialect{MavDialect::Auto}; // conf "MavlinkDialect"
+    unsigned long min_free_space;                 // conf "MinFreeSpace"
+    unsigned long max_log_files;                  // conf "MaxLogFiles"
 };
 
 class LogEndpoint : public Endpoint {
@@ -80,8 +91,8 @@ protected:
 
 private:
     int _get_file(const char *extension);
-    uint32_t _get_prefix(DIR *dir);
-    DIR *_open_or_create_dir(const char *name);
+    static uint32_t _get_prefix(DIR *dir);
+    static DIR *_open_or_create_dir(const char *name);
 
     /**
      * Delete old logs until a certain amount of free space and total number of log files are met.

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include <common/conf_file.h>
+
 #include <aio.h>
 #include <assert.h>
 #include <dirent.h>
@@ -58,6 +60,11 @@ public:
      * lost power.
      */
     void mark_unfinished_logs();
+
+    static const ConfFile::OptionsTable option_table[5];
+    static int parse_mavlink_dialect(const char *val, size_t val_len, void *storage,
+                                     size_t storage_len);
+    static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
 
 protected:
     const char *_logs_dir;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             char *ip;
             unsigned long port;
             UdpEndpointConfig opt_udp{};
-            opt_udp.name = "";
+            opt_udp.name = "CLI";
 
             if (split_on_last_colon(optarg, &ip, &port) < 0) {
                 log_error("Invalid port in argument: %s", optarg);
@@ -269,7 +269,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             unsigned long port;
 
             TcpEndpointConfig opt_tcp{};
-            opt_tcp.name = "";
+            opt_tcp.name = "CLI";
 
             if (split_on_last_colon(optarg, &ip, &port) < 0) {
                 log_error("Invalid port in argument: %s", optarg);
@@ -324,7 +324,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
 
         if (stat(base, &st) == -1 || !S_ISCHR(st.st_mode)) {
             UdpEndpointConfig opt_udp{};
-            opt_udp.name = "";
+            opt_udp.name = "CLI";
 
             opt_udp.port = number;
             if (ULONG_MAX == opt_udp.port) {
@@ -345,7 +345,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             config.udp_configs.push_back(opt_udp);
         } else {
             UartEndpointConfig opt_uart{};
-            opt_uart.name = "";
+            opt_uart.name = "CLI";
             opt_uart.device = std::string(base);
 
             const char *bauds = number != ULONG_MAX ? base + strlen(base) + 1 : nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <limits.h>
 #include <regex>
 #include <stddef.h>
+#include <stdexcept>
 #include <stdio.h>
 #include <string>
 #include <sys/stat.h>
@@ -33,29 +34,18 @@
 
 #include "comm.h"
 #include "endpoint.h"
+#include "logendpoint.h"
 #include "mainloop.h"
 
-#define MAVLINK_TCP_PORT          5760
-#define DEFAULT_BAUDRATE          115200U
-#define DEFAULT_CONFFILE          "/etc/mavlink-router/main.conf"
-#define DEFAULT_CONF_DIR          "/etc/mavlink-router/config.d"
-#define DEFAULT_RETRY_TCP_TIMEOUT 5
+#define MAVLINK_TCP_PORT              5760
+#define DEFAULT_REPORT_MSG_STATISTICS false
+#define DEFAULT_DEBUG_LOG_LEVEL       Log::Level::INFO
+#define DEFAULT_BAUDRATE              115200U
+#define DEFAULT_CONFFILE              "/etc/mavlink-router/main.conf"
+#define DEFAULT_CONF_DIR              "/etc/mavlink-router/config.d"
+#define DEFAULT_RETRY_TCP_TIMEOUT     5
 
 extern const char *BUILD_VERSION;
-
-static struct options opt = {
-    .endpoints = nullptr,
-    .conf_file_name = nullptr,
-    .conf_dir = nullptr,
-    .tcp_port = ULONG_MAX,
-    .report_msg_statistics = false,
-    .logs_dir = nullptr,
-    .log_mode = LogMode::always,
-    .debug_log_level = (int)Log::Level::INFO,
-    .mavlink_dialect = Auto,
-    .min_free_space = 0,
-    .max_log_files = 0,
-};
 
 static const struct option long_options[] = {{"endpoints", required_argument, nullptr, 'e'},
                                              {"conf-file", required_argument, nullptr, 'c'},
@@ -101,20 +91,13 @@ static void help(FILE *fp)
         program_invocation_short_name);
 }
 
-static unsigned long find_next_endpoint_port(const char *ip)
+static uint32_t find_next_udp_port(const std::string &ip, const Configuration &config)
 {
-    unsigned long port = 14550U;
+    uint32_t port = 14550U;
 
-    while (true) {
-        struct endpoint_config *conf;
-
-        for (conf = opt.endpoints; conf != nullptr; conf = conf->next) {
-            if (conf->type == Udp && streq(conf->address, ip) && conf->port == port) {
-                port++;
-                break;
-            }
-        }
-        if (conf == nullptr) {
+    for (const auto &c : config.udp_configs) {
+        if (ip == c.address && port == c.port) {
+            port++;
             break;
         }
     }
@@ -141,263 +124,43 @@ static int split_on_last_colon(const char *str, char **base, unsigned long *numb
     return 0;
 }
 
-static bool validate_ipv6(const char *ip)
+static bool validate_ipv6(const std::string &ip)
 {
     // simplyfied pattern
     std::regex ipv6_regex("\\[(([a-f\\d]{0,4}:)+[a-f\\d]{0,4})\\]");
     return std::regex_match(ip, ipv6_regex);
 }
 
-static bool validate_ipv4(const char *ip)
+static bool validate_ipv4(const std::string &ip)
 {
     std::regex ipv4_regex("(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})");
     return regex_match(ip, ipv4_regex);
 }
 
-static bool validate_ip(const char *ip)
+static bool validate_ip(const std::string &ip)
 {
     return validate_ipv4(ip) || validate_ipv6(ip);
 }
 
-static int log_level_from_str(const char *str)
+static Log::Level log_level_from_str(const char *str)
 {
     if (strcaseeq(str, "error")) {
-        return (int)Log::Level::ERROR;
+        return Log::Level::ERROR;
     }
     if (strcaseeq(str, "warning")) {
-        return (int)Log::Level::WARNING;
+        return Log::Level::WARNING;
     }
     if (strcaseeq(str, "info")) {
-        return (int)Log::Level::INFO;
+        return Log::Level::INFO;
     }
     if (strcaseeq(str, "debug")) {
-        return (int)Log::Level::DEBUG;
+        return Log::Level::DEBUG;
     }
 
-    return -EINVAL;
+    throw std::invalid_argument("log_level_from_str: unkown string value");
 }
 
-static int add_tcp_endpoint_address(const char *name, size_t name_len, const char *ip,
-                                    long unsigned port, int timeout, const char *msgIdFilter)
-{
-    int ret;
-
-    auto *conf = (struct endpoint_config *)calloc(1, sizeof(struct endpoint_config));
-    assert_or_return(conf, -ENOMEM);
-    conf->type = Tcp;
-    conf->port = ULONG_MAX;
-
-    if ((conf->name == nullptr) && (name != nullptr)) {
-        conf->name = strndup(name, name_len);
-        if (conf->name == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    if (ip != nullptr) {
-        free(conf->address);
-        conf->address = strdup(ip);
-        if (conf->address == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    if (conf->address == nullptr) {
-        ret = -EINVAL;
-        goto fail;
-    }
-
-    if (msgIdFilter != nullptr) {
-        conf->msgIdFilter = strdup(msgIdFilter);
-        if (conf->msgIdFilter == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    if (port != ULONG_MAX) {
-        conf->port = port;
-    }
-
-    if (conf->port == ULONG_MAX) {
-        ret = -EINVAL;
-        goto fail;
-    }
-
-    conf->retry_timeout = timeout;
-
-    conf->next = opt.endpoints;
-    opt.endpoints = conf;
-
-    return 0;
-
-fail:
-    free(conf->address);
-    free(conf->name);
-    free(conf);
-
-    return ret;
-}
-
-static int add_endpoint_address(const char *name, size_t name_len, const char *ip,
-                                long unsigned port, bool server, const char *msgIdFilter)
-{
-    int ret;
-
-    auto *conf = (struct endpoint_config *)calloc(1, sizeof(struct endpoint_config));
-    assert_or_return(conf, -ENOMEM);
-    conf->type = Udp;
-    conf->port = ULONG_MAX;
-
-    if ((conf->name == nullptr) && (name != nullptr)) {
-        conf->name = strndup(name, name_len);
-        if (conf->name == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    if (ip != nullptr) {
-        free(conf->address);
-        conf->address = strdup(ip);
-        if (conf->address == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    if (conf->address == nullptr) {
-        ret = -EINVAL;
-        goto fail;
-    }
-
-    if (msgIdFilter != nullptr) {
-        conf->msgIdFilter = strdup(msgIdFilter);
-        if (conf->msgIdFilter == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    if (port != ULONG_MAX) {
-        conf->port = port;
-    }
-
-    if (conf->port == ULONG_MAX) {
-        conf->port = find_next_endpoint_port(conf->address);
-    }
-
-    conf->server = server;
-
-    conf->next = opt.endpoints;
-    opt.endpoints = conf;
-
-    return 0;
-
-fail:
-    free(conf->address);
-    free(conf->name);
-    free(conf);
-
-    return ret;
-}
-
-static std::vector<unsigned long> *strlist_to_ul(const char *list, const char *listname,
-                                                 const char *delim, unsigned long default_value)
-{
-    char *s, *tmp_str;
-    std::unique_ptr<std::vector<unsigned long>> v{new std::vector<unsigned long>()};
-
-    if ((list == nullptr) || list[0] == '\0') {
-        v->push_back(default_value);
-        return v.release();
-    }
-
-    tmp_str = strdup(list);
-    if (tmp_str == nullptr) {
-        return nullptr;
-    }
-
-    s = strtok(tmp_str, delim);
-    while (s != nullptr) {
-        unsigned long l;
-        if (safe_atoul(s, &l) < 0) {
-            log_error("Invalid %s %s", listname, s);
-            goto error;
-        }
-        v->push_back(l);
-        s = strtok(nullptr, delim);
-    }
-
-    free(tmp_str);
-
-    if (v->empty()) {
-        log_error("No valid %s on %s", listname, list);
-        return nullptr;
-    }
-
-    return v.release();
-
-error:
-    free(tmp_str);
-    return nullptr;
-}
-
-static int add_uart_endpoint(const char *name, size_t name_len, const char *uart_device,
-                             const char *bauds, bool flowcontrol, const char *msgIdFilter)
-{
-    int ret;
-
-    auto *conf = (struct endpoint_config *)calloc(1, sizeof(struct endpoint_config));
-    assert_or_return(conf, -ENOMEM);
-    conf->type = Uart;
-
-    if (name != nullptr) {
-        conf->name = strndup(name, name_len);
-        if (conf->name == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    conf->device = strdup(uart_device);
-    if (conf->device == nullptr) {
-        ret = -ENOMEM;
-        goto fail;
-    }
-
-    conf->bauds = strlist_to_ul(bauds, "baud", ",", DEFAULT_BAUDRATE);
-    if (conf->bauds == nullptr) {
-        ret = -EINVAL;
-        goto fail;
-    }
-
-    if (msgIdFilter != nullptr) {
-        conf->msgIdFilter = strdup(msgIdFilter);
-        if (conf->msgIdFilter == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
-    conf->flowcontrol = flowcontrol;
-
-    conf->next = opt.endpoints;
-    opt.endpoints = conf;
-
-    return 0;
-
-fail:
-    free(conf->device);
-    free(conf->name);
-    free(conf);
-
-    return ret;
-}
-
-static bool pre_parse_argv(int argc, char *argv[])
+static bool pre_parse_argv(int argc, char *argv[], Configuration &config)
 {
     // This function parses only conf-file and conf-dir from
     // command line, so we can read the conf files.
@@ -409,11 +172,11 @@ static bool pre_parse_argv(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, short_options, long_options, nullptr)) >= 0) {
         switch (c) {
         case 'c': {
-            opt.conf_file_name = optarg;
+            config.conf_file_name = optarg;
             break;
         }
         case 'd': {
-            opt.conf_dir = optarg;
+            config.conf_dir = optarg;
             break;
         }
         case 'V':
@@ -428,7 +191,7 @@ static bool pre_parse_argv(int argc, char *argv[])
     return true;
 }
 
-static int parse_argv(int argc, char *argv[])
+static int parse_argv(int argc, char *argv[], Configuration &config)
 {
     int c;
     struct stat st;
@@ -444,28 +207,39 @@ static int parse_argv(int argc, char *argv[])
         case 'e': {
             char *ip;
             unsigned long port;
+            UdpEndpointConfig opt_udp{};
+            opt_udp.name = "";
 
             if (split_on_last_colon(optarg, &ip, &port) < 0) {
                 log_error("Invalid port in argument: %s", optarg);
                 help(stderr);
                 return -EINVAL;
             }
-            if (!validate_ip(ip)) {
+            if (ULONG_MAX != port) {
+                opt_udp.port = port;
+            } else {
+                opt_udp.port = find_next_udp_port(opt_udp.address, config);
+            }
+
+            opt_udp.address = std::string(ip);
+            if (!validate_ip(opt_udp.address)) {
                 log_error("Invalid IP address in argument: %s", optarg);
                 help(stderr);
                 return -EINVAL;
             }
 
-            add_endpoint_address(nullptr, 0, ip, port, false, nullptr);
+            opt_udp.mode = UdpEndpointConfig::Mode::Client;
+            config.udp_configs.push_back(opt_udp);
+
             free(ip);
             break;
         }
         case 'r': {
-            opt.report_msg_statistics = true;
+            config.report_msg_statistics = true;
             break;
         }
         case 't': {
-            if (safe_atoul(optarg, &opt.tcp_port) < 0) {
+            if (safe_atoul(optarg, &config.tcp_port) < 0) {
                 log_error("Invalid argument for tcp-port = %s", optarg);
                 help(stderr);
                 return -EINVAL;
@@ -473,45 +247,54 @@ static int parse_argv(int argc, char *argv[])
             break;
         }
         case 'l': {
-            opt.logs_dir = strdup(optarg);
+            config.log_config.logs_dir = strdup(optarg);
             break;
         }
         case 'g': {
-            int lvl = log_level_from_str(optarg);
-            if (lvl == -EINVAL) {
+            try {
+                config.debug_log_level = log_level_from_str(optarg);
+            } catch (const std::exception &e) {
                 log_error("Invalid argument for debug-log-level = %s", optarg);
                 help(stderr);
                 return -EINVAL;
             }
-            opt.debug_log_level = lvl;
             break;
         }
         case 'v': {
-            opt.debug_log_level = (int)Log::Level::DEBUG;
+            config.debug_log_level = Log::Level::DEBUG;
             break;
         }
         case 'p': {
             char *ip;
             unsigned long port;
 
+            TcpEndpointConfig opt_tcp{};
+            opt_tcp.name = "";
+
             if (split_on_last_colon(optarg, &ip, &port) < 0) {
                 log_error("Invalid port in argument: %s", optarg);
                 help(stderr);
                 return -EINVAL;
             }
-            if (port == ULONG_MAX) {
+
+            opt_tcp.port = port;
+            if (ULONG_MAX == opt_tcp.port) {
                 log_error("Missing port in argument: %s", optarg);
                 free(ip);
                 help(stderr);
                 return -EINVAL;
             }
-            if (!validate_ip(ip)) {
+
+            opt_tcp.address = std::string(ip);
+            if (!validate_ip(opt_tcp.address)) {
                 log_error("Invalid IP address in argument: %s", optarg);
                 help(stderr);
                 return -EINVAL;
             }
 
-            add_tcp_endpoint_address(nullptr, 0, ip, port, DEFAULT_RETRY_TCP_TIMEOUT, nullptr);
+            opt_tcp.retry_timeout = DEFAULT_RETRY_TCP_TIMEOUT;
+            config.tcp_configs.push_back(opt_tcp);
+
             free(ip);
             break;
         }
@@ -540,26 +323,38 @@ static int parse_argv(int argc, char *argv[])
         }
 
         if (stat(base, &st) == -1 || !S_ISCHR(st.st_mode)) {
-            if (number == ULONG_MAX) {
+            UdpEndpointConfig opt_udp{};
+            opt_udp.name = "";
+
+            opt_udp.port = number;
+            if (ULONG_MAX == opt_udp.port) {
                 log_error("Invalid argument for UDP port = %s", argv[optind]);
                 help(stderr);
                 free(base);
                 return -EINVAL;
             }
-            if (!validate_ip(base)) {
+
+            opt_udp.address = std::string(base);
+            if (!validate_ip(opt_udp.address)) {
                 log_error("Invalid IP address in argument: %s", argv[optind]);
                 help(stderr);
                 return -EINVAL;
             }
 
-            add_endpoint_address(nullptr, 0, base, number, true, nullptr);
+            opt_udp.mode = UdpEndpointConfig::Mode::Server;
+            config.udp_configs.push_back(opt_udp);
         } else {
+            UartEndpointConfig opt_uart{};
+            opt_uart.name = "";
+            opt_uart.device = std::string(base);
+
             const char *bauds = number != ULONG_MAX ? base + strlen(base) + 1 : nullptr;
-            int ret = add_uart_endpoint(nullptr, 0, base, bauds, false, nullptr);
-            if (ret < 0) {
-                free(base);
-                return ret;
+            if (bauds != nullptr) {
+                opt_uart.baudrates.push_back(atoi(bauds));
             }
+            opt_uart.baudrates.push_back(DEFAULT_BAUDRATE);
+
+            config.uart_configs.push_back(opt_uart);
         }
         free(base);
         optind++;
@@ -568,33 +363,33 @@ static int parse_argv(int argc, char *argv[])
     return 2;
 }
 
-static const char *get_conf_file_name()
+static std::string get_conf_file_name(const Configuration &config)
 {
     char *s;
 
-    if (opt.conf_file_name != nullptr) {
-        return opt.conf_file_name;
+    if (!config.conf_file_name.empty()) {
+        return config.conf_file_name;
     }
 
     s = getenv("MAVLINK_ROUTERD_CONF_FILE");
     if (s != nullptr) {
-        return s;
+        return std::string(s);
     }
 
     return DEFAULT_CONFFILE;
 }
 
-static const char *get_conf_dir()
+static std::string get_conf_dir(const Configuration &config)
 {
     char *s;
 
-    if (opt.conf_dir != nullptr) {
-        return opt.conf_dir;
+    if (!config.conf_dir.empty()) {
+        return config.conf_dir;
     }
 
     s = getenv("MAVLINK_ROUTERD_CONF_DIR");
     if (s != nullptr) {
-        return s;
+        return std::string(s);
     }
 
     return DEFAULT_CONF_DIR;
@@ -606,9 +401,9 @@ static int parse_mavlink_dialect(const char *val, size_t val_len, void *storage,
     assert(storage);
     assert(val_len);
 
-    auto *dialect = (enum mavlink_dialect *)storage;
+    auto *dialect = (LogOptions::MavDialect *)storage;
 
-    if (storage_len < sizeof(options::mavlink_dialect)) {
+    if (storage_len < sizeof(LogOptions::mavlink_dialect)) {
         return -ENOBUFS;
     }
     if (val_len > INT_MAX) {
@@ -616,11 +411,11 @@ static int parse_mavlink_dialect(const char *val, size_t val_len, void *storage,
     }
 
     if (memcaseeq(val, val_len, "auto", sizeof("auto") - 1)) {
-        *dialect = Auto;
+        *dialect = LogOptions::MavDialect::Auto;
     } else if (memcaseeq(val, val_len, "common", sizeof("common") - 1)) {
-        *dialect = Common;
+        *dialect = LogOptions::MavDialect::Common;
     } else if (memcaseeq(val, val_len, "ardupilotmega", sizeof("ardupilotmega") - 1)) {
-        *dialect = Ardupilotmega;
+        *dialect = LogOptions::MavDialect::Ardupilotmega;
     } else {
         log_error("Invalid argument for MavlinkDialect = %.*s", (int)val_len, val);
         return -EINVAL;
@@ -636,7 +431,7 @@ static int parse_log_level(const char *val, size_t val_len, void *storage, size_
     assert(storage);
     assert(val_len);
 
-    if (storage_len < sizeof(options::debug_log_level)) {
+    if (storage_len < sizeof(Configuration::debug_log_level)) {
         return -ENOBUFS;
     }
     if (val_len > MAX_LOG_LEVEL_SIZE) {
@@ -644,12 +439,13 @@ static int parse_log_level(const char *val, size_t val_len, void *storage, size_
     }
 
     const char *log_level = strndupa(val, val_len);
-    int lvl = log_level_from_str(log_level);
-    if (lvl == -EINVAL) {
+    try {
+        auto *level = (Log::Level *)storage;
+        *level = log_level_from_str(log_level);
+    } catch (const std::exception &e) {
         log_error("Invalid argument for DebugLogLevel = %s", log_level);
         return -EINVAL;
     }
-    *((int *)storage) = lvl;
 
     return 0;
 }
@@ -662,7 +458,7 @@ static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t
     assert(storage);
     assert(val_len);
 
-    if (storage_len < sizeof(options::log_mode)) {
+    if (storage_len < sizeof(LogOptions::log_mode)) {
         return -ENOBUFS;
     }
     if (val_len > MAX_LOG_MODE_SIZE) {
@@ -685,7 +481,7 @@ static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t
 }
 #undef MAX_LOG_MODE_SIZE
 
-static int parse_mode(const char *val, size_t val_len, void *storage, size_t storage_len)
+static int parse_udp_mode(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
     assert(val);
     assert(storage);
@@ -698,14 +494,14 @@ static int parse_mode(const char *val, size_t val_len, void *storage, size_t sto
         return -EINVAL;
     }
 
-    bool *server = (bool *)storage;
+    auto *udp_mode = (UdpEndpointConfig::Mode *)storage;
     if (memcaseeq(val, val_len, "normal", sizeof("normal") - 1)) {
-        *server = false;
+        *udp_mode = UdpEndpointConfig::Mode::Client;
     } else if (memcaseeq(val, val_len, "eavesdropping", sizeof("eavesdropping") - 1)) {
         log_warning("Eavesdropping mode is deprecated and rather act like udpin/server");
-        *server = true;
+        *udp_mode = UdpEndpointConfig::Mode::Server;
     } else if (memcaseeq(val, val_len, "server", sizeof("server") - 1)) {
-        *server = true;
+        *udp_mode = UdpEndpointConfig::Mode::Server;
     } else {
         log_error("Unknown 'mode' key: %.*s", (int)val_len, val);
         return -EINVAL;
@@ -714,7 +510,52 @@ static int parse_mode(const char *val, size_t val_len, void *storage, size_t sto
     return 0;
 }
 
-static int parse_confs(ConfFile &conf)
+static int parse_uint8_vector(const char *val, size_t val_len, void *storage, size_t storage_len)
+{
+    assert(val);
+    assert(storage);
+    assert(val_len);
+
+    if (storage_len < sizeof(bool)) {
+        return -ENOBUFS;
+    }
+
+    char *filter_string = strndupa(val, val_len);
+    auto *target = (std::vector<uint8_t> *)storage;
+
+    char *token = strtok(filter_string, ",");
+    while (token != nullptr) {
+        target->push_back(atoi(token));
+        token = strtok(nullptr, ",");
+    }
+
+    return 0;
+}
+
+static int parse_baudrates(const char *val, size_t val_len, void *storage, size_t storage_len)
+{
+    assert(val);
+    assert(storage);
+    assert(val_len);
+
+    if (storage_len < sizeof(bool)) {
+        return -ENOBUFS;
+    }
+
+    char *filter_string = strndupa(val, val_len);
+    auto *target = (std::vector<speed_t> *)storage;
+
+    char *token = strtok(filter_string, ",");
+    while (token != nullptr) {
+        target->push_back(atoi(token));
+        token = strtok(nullptr, ",");
+    }
+    target->push_back(DEFAULT_BAUDRATE);
+
+    return 0;
+}
+
+static int parse_confs(ConfFile &conffile, Configuration &config)
 {
     int ret;
     size_t offset;
@@ -722,67 +563,63 @@ static int parse_confs(ConfFile &conf)
     const char *pattern;
 
     static const ConfFile::OptionsTable option_table[] = {
-        {"TcpServerPort", false, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(options, tcp_port)},
+        {"TcpServerPort", false, ConfFile::parse_ul,
+         OPTIONS_TABLE_STRUCT_FIELD(Configuration, tcp_port)},
         {"ReportStats", false, ConfFile::parse_bool,
-         OPTIONS_TABLE_STRUCT_FIELD(options, report_msg_statistics)},
-        {"MavlinkDialect", false, parse_mavlink_dialect,
-         OPTIONS_TABLE_STRUCT_FIELD(options, mavlink_dialect)},
-        {"Log", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(options, logs_dir)},
-        {"LogMode", false, parse_log_mode, OPTIONS_TABLE_STRUCT_FIELD(options, log_mode)},
+         OPTIONS_TABLE_STRUCT_FIELD(Configuration, report_msg_statistics)},
         {"DebugLogLevel", false, parse_log_level,
-         OPTIONS_TABLE_STRUCT_FIELD(options, debug_log_level)},
+         OPTIONS_TABLE_STRUCT_FIELD(Configuration, debug_log_level)},
+    };
+
+    static const ConfFile::OptionsTable option_table_log[] = {
+        {"Log", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(LogOptions, logs_dir)},
+        {"LogMode", false, parse_log_mode, OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_mode)},
+        {"MavlinkDialect", false, parse_mavlink_dialect,
+         OPTIONS_TABLE_STRUCT_FIELD(LogOptions, mavlink_dialect)},
         {"MinFreeSpace", false, ConfFile::parse_ul,
-         OPTIONS_TABLE_STRUCT_FIELD(options, min_free_space)},
+         OPTIONS_TABLE_STRUCT_FIELD(LogOptions, min_free_space)},
         {"MaxLogFiles", false, ConfFile::parse_ul,
-         OPTIONS_TABLE_STRUCT_FIELD(options, max_log_files)},
+         OPTIONS_TABLE_STRUCT_FIELD(LogOptions, max_log_files)},
     };
 
-    struct option_uart {
-        char *device;
-        char *bauds;
-        bool flowcontrol;
-        char *msgIdFilter;
-    };
     static const ConfFile::OptionsTable option_table_uart[] = {
-        {"baud", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_uart, bauds)},
-        {"device", true, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_uart, device)},
+        {"baud", false, parse_baudrates, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, baudrates)},
+        {"device", true, ConfFile::parse_stdstring,
+         OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, device)},
         {"FlowControl", false, ConfFile::parse_bool,
-         OPTIONS_TABLE_STRUCT_FIELD(option_uart, flowcontrol)},
-        {"AllowMsgIdOut", false, ConfFile::parse_str_dup,
-         OPTIONS_TABLE_STRUCT_FIELD(option_uart, msgIdFilter)},
+         OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
+        {"AllowMsgIdOut", false, parse_uint8_vector,
+         OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
     };
 
-    struct option_udp {
-        char *addr;
-        bool server;
-        unsigned long port;
-        char *msgIdFilter;
-    };
     static const ConfFile::OptionsTable option_table_udp[] = {
-        {"address", true, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
-        {"mode", true, parse_mode, OPTIONS_TABLE_STRUCT_FIELD(option_udp, server)},
-        {"port", false, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
-        {"filter", false, ConfFile::parse_str_dup,
-         OPTIONS_TABLE_STRUCT_FIELD(option_udp, msgIdFilter)}, // legacy AllowMsgIdOut
-        {"AllowMsgIdOut", false, ConfFile::parse_str_dup,
-         OPTIONS_TABLE_STRUCT_FIELD(option_udp, msgIdFilter)},
+        {"address", true, ConfFile::parse_stdstring,
+         OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
+        {"mode", true, parse_udp_mode, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
+        {"port", false, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
+        {"filter", false, parse_uint8_vector,
+         OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
+        {"AllowMsgIdOut", false, parse_uint8_vector,
+         OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     };
 
-    struct option_tcp {
-        char *addr;
-        unsigned long port;
-        int timeout;
-        char *msgIdFilter;
-    };
     static const ConfFile::OptionsTable option_table_tcp[] = {
-        {"address", true, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(option_tcp, addr)},
-        {"port", true, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(option_tcp, port)},
-        {"RetryTimeout", false, ConfFile::parse_i, OPTIONS_TABLE_STRUCT_FIELD(option_tcp, timeout)},
-        {"AllowMsgIdOut", false, ConfFile::parse_str_dup,
-         OPTIONS_TABLE_STRUCT_FIELD(option_tcp, msgIdFilter)},
+        {"address", true, ConfFile::parse_stdstring,
+         OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
+        {"port", true, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
+        {"RetryTimeout", false, ConfFile::parse_i,
+         OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
+        {"AllowMsgIdOut", false, parse_uint8_vector,
+         OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     };
 
-    ret = conf.extract_options("General", option_table, ARRAY_SIZE(option_table), &opt);
+    ret = conffile.extract_options("General", option_table, ARRAY_SIZE(option_table), &config);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = conffile.extract_options("General", option_table_log, ARRAY_SIZE(option_table_log),
+                                   &config.log_config);
     if (ret < 0) {
         return ret;
     }
@@ -790,16 +627,14 @@ static int parse_confs(ConfFile &conf)
     iter = {};
     pattern = "uartendpoint *";
     offset = strlen(pattern) - 1;
-    while (conf.get_sections(pattern, &iter) == 0) {
-        struct option_uart opt_uart = {nullptr, nullptr};
-        ret = conf.extract_options(&iter, option_table_uart, ARRAY_SIZE(option_table_uart),
-                                   &opt_uart);
+    while (conffile.get_sections(pattern, &iter) == 0) {
+        UartEndpointConfig opt_uart{};
+        ret = conffile.extract_options(&iter, option_table_uart, ARRAY_SIZE(option_table_uart),
+                                       &opt_uart);
         if (ret == 0) {
-            ret = add_uart_endpoint(iter.name + offset, iter.name_len - offset, opt_uart.device,
-                                    opt_uart.bauds, opt_uart.flowcontrol, opt_uart.msgIdFilter);
+            opt_uart.name = std::string(iter.name + offset, iter.name_len - offset);
+            config.uart_configs.push_back(opt_uart);
         }
-        free(opt_uart.device);
-        free(opt_uart.bauds);
         if (ret < 0) {
             return ret;
         }
@@ -808,27 +643,27 @@ static int parse_confs(ConfFile &conf)
     iter = {};
     pattern = "udpendpoint *";
     offset = strlen(pattern) - 1;
-    while (conf.get_sections(pattern, &iter) == 0) {
-        struct option_udp opt_udp = {nullptr, false, ULONG_MAX};
-        ret = conf.extract_options(&iter, option_table_udp, ARRAY_SIZE(option_table_udp), &opt_udp);
+    while (conffile.get_sections(pattern, &iter) == 0) {
+        UdpEndpointConfig opt_udp{};
+        opt_udp.port = ULONG_MAX; // unset port value to be checked later on
+        ret = conffile.extract_options(&iter, option_table_udp, ARRAY_SIZE(option_table_udp),
+                                       &opt_udp);
         if (ret == 0) {
-            if (opt_udp.server && opt_udp.port == ULONG_MAX) {
+            opt_udp.name = std::string(iter.name + offset, iter.name_len - offset);
+            if (opt_udp.mode == UdpEndpointConfig::Mode::Server && opt_udp.port == ULONG_MAX) {
                 log_error("Expected 'port' key for section %.*s", (int)iter.name_len, iter.name);
                 ret = -EINVAL;
             } else {
-                if (!validate_ip(opt_udp.addr)) {
+                if (!validate_ip(opt_udp.address)) {
                     log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len,
-                              iter.name, opt_udp.addr);
+                              iter.name, opt_udp.address.c_str());
                     ret = -EINVAL;
                 } else {
-                    ret = add_endpoint_address(iter.name + offset, iter.name_len - offset,
-                                               opt_udp.addr, opt_udp.port, opt_udp.server,
-                                               opt_udp.msgIdFilter);
+                    config.udp_configs.push_back(opt_udp);
                 }
             }
         }
 
-        free(opt_udp.addr);
         if (ret < 0) {
             return ret;
         }
@@ -837,22 +672,22 @@ static int parse_confs(ConfFile &conf)
     iter = {};
     pattern = "tcpendpoint *";
     offset = strlen(pattern) - 1;
-    while (conf.get_sections(pattern, &iter) == 0) {
-        struct option_tcp opt_tcp = {nullptr, ULONG_MAX, DEFAULT_RETRY_TCP_TIMEOUT};
-        ret = conf.extract_options(&iter, option_table_tcp, ARRAY_SIZE(option_table_tcp), &opt_tcp);
-
+    while (conffile.get_sections(pattern, &iter) == 0) {
+        TcpEndpointConfig opt_tcp{};
+        opt_tcp.port = ULONG_MAX; // unset port value to be checked later on
+        opt_tcp.retry_timeout = DEFAULT_RETRY_TCP_TIMEOUT;
+        ret = conffile.extract_options(&iter, option_table_tcp, ARRAY_SIZE(option_table_tcp),
+                                       &opt_tcp);
         if (ret == 0) {
-            if (!validate_ip(opt_tcp.addr)) {
+            opt_tcp.name = std::string(iter.name + offset, iter.name_len - offset);
+            if (!validate_ip(opt_tcp.address)) {
                 log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name,
-                          opt_tcp.addr);
+                          opt_tcp.address.c_str());
                 ret = -EINVAL;
             } else {
-                ret = add_tcp_endpoint_address(iter.name + offset, iter.name_len - offset,
-                                               opt_tcp.addr, opt_tcp.port, opt_tcp.timeout,
-                                               opt_tcp.msgIdFilter);
+                config.tcp_configs.push_back(opt_tcp);
             }
         }
-        free(opt_tcp.addr);
         if (ret < 0) {
             return ret;
         }
@@ -866,71 +701,72 @@ static int cmpstr(const void *s1, const void *s2)
     return strcmp(*(const char **)s1, *(const char **)s2);
 }
 
-static int parse_conf_files()
+static int parse_conf_files(Configuration &config)
 {
     DIR *dir;
     struct dirent *ent;
-    const char *filename, *dirname;
     int ret = 0;
     char *files[128] = {};
     int i = 0, j = 0;
-    ConfFile conf;
+
+    ConfFile conffile;
 
     // First, open default conf file
-    filename = get_conf_file_name();
-    ret = conf.parse(filename);
+    auto filename = get_conf_file_name(config);
+    ret = conffile.parse(filename);
 
     // If there's no default conf file, everything is good
     if (ret < 0 && ret != -ENOENT) {
         return ret;
     }
 
-    dirname = get_conf_dir();
     // Then, parse all files on configuration directory
-    dir = opendir(dirname);
-    if (dir == nullptr) {
-        return parse_confs(conf);
+    auto dirname = get_conf_dir(config);
+    dir = opendir(dirname.c_str());
+    if (dir != nullptr) {
+        while ((ent = readdir(dir)) != nullptr) {
+            char path[PATH_MAX];
+            struct stat st;
+
+            ret = snprintf(path, sizeof(path), "%s/%s", dirname.c_str(), ent->d_name);
+            if (ret >= (int)sizeof(path)) {
+                log_error("Couldn't open directory %s", dirname.c_str());
+                ret = -EINVAL;
+                goto fail;
+            }
+            if (stat(path, &st) < 0 || !S_ISREG(st.st_mode)) {
+                continue;
+            }
+            files[i] = strdup(path);
+            if (files[i] == nullptr) {
+                ret = -ENOMEM;
+                goto fail;
+            }
+            i++;
+
+            if ((size_t)i > sizeof(files) / sizeof(*files)) {
+                log_warning("Too many files on %s. Not all of them will be considered",
+                            dirname.c_str());
+                break;
+            }
+        }
+
+        qsort(files, (size_t)i, sizeof(char *), cmpstr);
+
+        for (j = 0; j < i; j++) {
+            ret = conffile.parse(files[j]);
+            if (ret < 0) {
+                goto fail;
+            }
+            free(files[j]);
+        }
+
+        closedir(dir);
     }
 
-    while ((ent = readdir(dir)) != nullptr) {
-        char path[PATH_MAX];
-        struct stat st;
+    // Finally get configuration values from all config files
+    return parse_confs(conffile, config);
 
-        ret = snprintf(path, sizeof(path), "%s/%s", dirname, ent->d_name);
-        if (ret >= (int)sizeof(path)) {
-            log_error("Couldn't open directory %s", dirname);
-            ret = -EINVAL;
-            goto fail;
-        }
-        if (stat(path, &st) < 0 || !S_ISREG(st.st_mode)) {
-            continue;
-        }
-        files[i] = strdup(path);
-        if (files[i] == nullptr) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-        i++;
-
-        if ((size_t)i > sizeof(files) / sizeof(*files)) {
-            log_warning("Too many files on %s. Not all of them will be considered", dirname);
-            break;
-        }
-    }
-
-    qsort(files, (size_t)i, sizeof(char *), cmpstr);
-
-    for (j = 0; j < i; j++) {
-        ret = conf.parse(files[j]);
-        if (ret < 0) {
-            goto fail;
-        }
-        free(files[j]);
-    }
-
-    closedir(dir);
-
-    return parse_confs(conf);
 fail:
     while (j < i) {
         free(files[j++]);
@@ -945,51 +781,44 @@ int main(int argc, char *argv[])
 {
     Mainloop &mainloop = Mainloop::init();
     int retcode;
+    Configuration config{};
+    config.tcp_port = MAVLINK_TCP_PORT;
+    config.report_msg_statistics = DEFAULT_REPORT_MSG_STATISTICS;
+    config.debug_log_level = DEFAULT_DEBUG_LOG_LEVEL;
 
     Log::open();
+    log_info(PACKAGE " version %s", BUILD_VERSION);
 
-    if (!pre_parse_argv(argc, argv)) {
+    if (!pre_parse_argv(argc, argv, config)) {
         Log::close();
         return 0;
     }
 
-    if (parse_conf_files() < 0) {
+    // Build remaining config from config files and CLI parameters
+    if (parse_conf_files(config) < 0) {
         goto close_log;
     }
 
-    if (parse_argv(argc, argv) != 2) {
+    if (parse_argv(argc, argv, config) != 2) {
         goto close_log;
     }
-
-    Log::set_max_level((Log::Level)opt.debug_log_level);
-
     dbg("Cmd line and options parsed");
 
+    Log::set_max_level(config.debug_log_level);
+
+    // Create endpoint instances and run
     if (mainloop.open() < 0) {
         goto close_log;
     }
 
-    if (opt.tcp_port == ULONG_MAX) {
-        opt.tcp_port = MAVLINK_TCP_PORT;
-    }
-
-    if (!mainloop.add_endpoints(mainloop, &opt)) {
-        goto endpoint_error;
+    if (!mainloop.add_endpoints(config)) {
+        goto close_log;
     }
 
     retcode = mainloop.loop();
 
-    mainloop.free_endpoints(&opt);
-
-    free(opt.logs_dir);
-
     Log::close();
-
     return retcode ? EXIT_FAILURE : 0;
-
-endpoint_error:
-    mainloop.free_endpoints(&opt);
-    free(opt.logs_dir);
 
 close_log:
     Log::close();

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -380,8 +380,7 @@ bool Mainloop::add_endpoints(const Configuration &config)
     for (const auto &conf : config.udp_configs) {
         auto udp = std::make_shared<UdpEndpoint>(conf.name);
 
-        bool is_server_mode = (UdpEndpointConfig::Mode::Server == conf.mode);
-        if (udp->open(conf.address.c_str(), conf.port, is_server_mode) < 0) {
+        if (udp->open(conf.address.c_str(), conf.port, conf.mode) < 0) {
             log_error("Could not open %s:%ld", conf.address.c_str(), conf.port);
             return false;
         }

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -391,18 +391,15 @@ bool Mainloop::add_endpoints(const Configuration &config)
     if (!conf.logs_dir.empty()) {
         switch (conf.mavlink_dialect) {
         case LogOptions::MavDialect::Ardupilotmega:
-            this->_log_endpoint = std::make_shared<BinLog>(conf.logs_dir.c_str(), conf.log_mode,
-                                                           conf.min_free_space, conf.max_log_files);
+            this->_log_endpoint = std::make_shared<BinLog>(conf);
             break;
 
         case LogOptions::MavDialect::Common:
-            this->_log_endpoint = std::make_shared<ULog>(conf.logs_dir.c_str(), conf.log_mode,
-                                                         conf.min_free_space, conf.max_log_files);
+            this->_log_endpoint = std::make_shared<ULog>(conf);
             break;
 
         case LogOptions::MavDialect::Auto:
-            this->_log_endpoint = std::make_shared<AutoLog>(
-                conf.logs_dir.c_str(), conf.log_mode, conf.min_free_space, conf.max_log_files);
+            this->_log_endpoint = std::make_shared<AutoLog>(conf);
             break;
 
             // no default case on purpose

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -94,9 +94,7 @@ public:
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;
 
-    // TCP endpoints are separarte b/c process_tcp_hangups() just needs TCP instances
     std::vector<std::shared_ptr<Endpoint>> g_endpoints{};
-    std::vector<std::shared_ptr<TcpEndpoint>> g_tcp_endpoints{};
     int g_tcp_fd = -1; ///< for TCP server
     std::shared_ptr<LogEndpoint> _log_endpoint{nullptr};
 

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -91,8 +91,6 @@ public:
      */
     void request_exit(int retcode);
 
-    void add_tcp_retry(TcpEndpoint *tcp);
-
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;
 
@@ -110,7 +108,6 @@ private:
 
     int tcp_open(unsigned long tcp_port);
     void _del_timeouts();
-    void _add_tcp_endpoint(TcpEndpoint *tcp);
     bool _retry_timeout_cb(void *data);
     bool _log_aggregate_timeout(void *data);
 

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -91,6 +91,8 @@ public:
      */
     void request_exit(int retcode);
 
+    void add_tcp_retry(TcpEndpoint *tcp);
+
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;
 
@@ -109,7 +111,6 @@ private:
     int tcp_open(unsigned long tcp_port);
     void _del_timeouts();
     void _add_tcp_endpoint(TcpEndpoint *tcp);
-    void _add_tcp_retry(TcpEndpoint *tcp);
     bool _retry_timeout_cb(void *data);
     bool _log_aggregate_timeout(void *data);
 

--- a/src/ulog.h
+++ b/src/ulog.h
@@ -23,8 +23,8 @@
 
 class ULog : public LogEndpoint {
 public:
-    ULog(const char *logs_dir, LogMode mode, unsigned long min_free_space, unsigned long max_files)
-        : LogEndpoint{"ULog", logs_dir, mode, min_free_space, max_files}
+    ULog(LogOptions conf)
+        : LogEndpoint{"ULog", conf}
     {
     }
 


### PR DESCRIPTION
The configuration of mavlink-router has to be merged from config file(s) and CLI options. Previously the config file was parsed to one set of structs, passed to a function as a set of parameters (instead of the full struct), which converted the options to another config structure collecting a list of endpoints, which was finally used to actually create the endpoints. I think having two config structs is quite confusing and overly complicated.

This PR reworks the internal flow of the configuration parameters to be like this:
- Parse config file(s) and CLI options to one struct per endpoint type (UDP, TCP, UART and Log)
- Have a single config struct with the full, merged configuration (global options + one list of endpoints per type), which is properly owned by the main function instead of a global variable
- Mainloop still creates the actual endpoint instances from the single configuration
- Pass a full struct instead of multiple parameters to methods, where possible. 
This leads to less parameters and therefore makes future extensions easier.

Additional changes:
- Fixed (and extended) some log messages
- Move config file option tables to be owned by the endpoints instead of the main.cpp
- Rework the mainloop to only use one list of endpoints (instead of one for TCP + and another for everything else)
- Make use of std::vector instead of home-grown concatenated lists (easier to read/ understand and less error-prone when being extended)
- Configuration validation is a static method of each endpoint now instead of being scattered around multiple places in the main.cpp
- Endpoint setup is mainly done with one method and the config struct instead of multiple setters now

Sorry to have so many things in one PR, but they are closely related.