### PR TITLE
logendpoint: fix not not parsing config file correctly

### DIFF
--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -45,7 +45,7 @@
 #define MAX_RETRIES   10
 
 const ConfFile::OptionsTable LogEndpoint::option_table[] = {
-    {"Log", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(LogOptions, logs_dir)},
+    {"Log", false, ConfFile::parse_stdstring, OPTIONS_TABLE_STRUCT_FIELD(LogOptions, logs_dir)},
     {"LogMode", false, LogEndpoint::parse_log_mode,
      OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_mode)},
     {"MavlinkDialect", false, LogEndpoint::parse_mavlink_dialect,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,7 +228,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             break;
         }
         case 'l': {
-            config.log_config.logs_dir = strdup(optarg);
+            config.log_config.logs_dir.assign((const char *)optarg);
             break;
         }
         case 'g': {


### PR DESCRIPTION
We changed the storage type from char* to std::string bug failed to
update the configfile and arg parse.

Fix: #309