### PR TITLE
Fix assert crash when stopping log

### DIFF
--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -76,7 +76,6 @@ Mainloop &Mainloop::instance()
 void Mainloop::request_exit(int retcode)
 {
     _retcode = retcode;
-    _initialized = false;
     should_exit.store(true, std::memory_order_relaxed);
 }
 

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -63,6 +63,11 @@ Mainloop &Mainloop::init()
     return _instance;
 }
 
+void Mainloop::teardown()
+{
+    _initialized = false;
+}
+
 Mainloop &Mainloop::instance()
 {
     return _instance;

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -84,6 +84,12 @@ public:
      */
     static Mainloop &init();
 
+    /*
+     * De-initialize singleton so we can start a fresh on the same
+     * thread
+     */
+    static void teardown();
+
     static Mainloop &instance();
 
     /*

--- a/src/mainloop_test.cpp
+++ b/src/mainloop_test.cpp
@@ -9,6 +9,7 @@ TEST(MainLoopTest, termination)
     mainloop.request_exit(0);
     int ret = mainloop.loop();
     EXPECT_EQ(0, ret);
+    mainloop.teardown();
 }
 
 TEST(MainLoopTest, wrong_termination)
@@ -18,4 +19,5 @@ TEST(MainLoopTest, wrong_termination)
     mainloop.request_exit(-1);
     int ret = mainloop.loop();
     EXPECT_EQ(-1, ret);
+    mainloop.teardown();
 }


### PR DESCRIPTION
When we exit mavlink-router we call logger->stop() to stop
and properly finalize the flight stack log. However this
call may want to send something to the flight stack to stop
sending the log.

We don't care about that call as if we are really stopping the flight
stack should detect the other side died/disconnected after a timeout.
Instead of marking the mainloop as not initiliazed upon signal,
serialize it with the other shutdown task in the main loop.

This fixes the crash:
    Logging target system_id=1 on 00001-2021-12-29_23-57-32.bin
    mavlink-routerd: ../src/mainloop.h:77: static Mainloop&Mainloop::get_instance(): Assertion `_initialized' failed.
    Aborted