### PR TITLE
Warning and error fixs

### DIFF
--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -80,10 +80,8 @@ int BinLog::write_msg(const struct buffer *buffer)
     uint32_t msg_id;
     uint8_t *payload;
     uint16_t payload_len;
-    uint8_t trimmed_zeros;
     uint8_t source_system_id;
     uint8_t source_component_id;
-    mavlink_remote_log_data_block_t *binlog_data;
 
     if (mavlink2) {
         auto *msg = (struct mavlink_router_mavlink2_header *)buffer->data;
@@ -124,12 +122,14 @@ int BinLog::write_msg(const struct buffer *buffer)
         payload_len = msg_entry->max_msg_len;
     }
 
+    uint8_t trimmed_zeros;
     if (mavlink2) {
         trimmed_zeros = get_trimmed_zeros(msg_entry, buffer);
     } else {
         trimmed_zeros = 0;
     }
 
+    mavlink_remote_log_data_block_t *binlog_data;
     if (trimmed_zeros) {
         binlog_data
             = (mavlink_remote_log_data_block_t *)alloca(sizeof(mavlink_remote_log_data_block_t));

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -127,6 +127,13 @@ void LogEndpoint::mark_unfinished_logs()
 
 void LogEndpoint::_delete_old_logs()
 {
+    // check first the directory exist before looking for space to prevent failure
+    DIR *dir = opendir(_config.logs_dir.c_str());
+
+    // Assume the directory does not exist if opendir failed
+    if (!dir) {
+        return;
+    }
 
     struct statvfs buf;
     uint64_t free_space;
@@ -141,13 +148,7 @@ void LogEndpoint::_delete_old_logs()
 
     // This check is not necessary, it just saves on some file IO.
     if (free_space > _config.min_free_space && _config.max_log_files == 0) {
-        return;
-    }
-
-    DIR *dir = opendir(_config.logs_dir.c_str());
-
-    // Assume the directory does not exist if opendir failed
-    if (!dir) {
+        closedir(dir);
         return;
     }
 

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -249,12 +249,11 @@ uint32_t LogEndpoint::_get_prefix(DIR *dir)
 
 DIR *LogEndpoint::_open_or_create_dir(const char *name)
 {
-    int r;
     DIR *dir = opendir(name);
 
     // If failed because dir doesn't exist, try to create it
     if (!dir && errno == ENOENT) {
-        r = mkdir_p(name, strlen(name), 0755);
+        const int r = mkdir_p(name, strlen(name), 0755);
         if (r < 0) {
             errno = -r;
             return nullptr;
@@ -267,14 +266,10 @@ DIR *LogEndpoint::_open_or_create_dir(const char *name)
 
 int LogEndpoint::_get_file(const char *extension)
 {
-    time_t t = time(nullptr);
-    struct tm *timeinfo = localtime(&t);
-    uint32_t i;
-    int j, r;
-    DIR *dir;
-    int dir_fd;
+    const time_t t = time(nullptr);
+    const struct tm *timeinfo = localtime(&t);
 
-    dir = _open_or_create_dir(_config.logs_dir.c_str());
+    DIR *dir = _open_or_create_dir(_config.logs_dir.c_str());
     if (!dir) {
         log_error("Could not open log dir (%m)");
         return -1;
@@ -282,11 +277,11 @@ int LogEndpoint::_get_file(const char *extension)
     // Close dir when leaving function.
     std::shared_ptr<void> defer(dir, [](DIR *p) { closedir(p); });
 
-    i = _get_prefix(dir);
-    dir_fd = dirfd(dir);
+    const uint32_t i = _get_prefix(dir);
+    const int dir_fd = dirfd(dir);
 
-    for (j = 0; j <= MAX_RETRIES; j++) {
-        r = snprintf(_filename, sizeof(_filename), "%05u-%i-%02i-%02i_%02i-%02i-%02i.%s", i + j,
+    for (int j = 0; j <= MAX_RETRIES; j++) {
+        int r = snprintf(_filename, sizeof(_filename), "%05u-%i-%02i-%02i_%02i-%02i-%02i.%s", i + j,
                      timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday,
                      timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, extension);
 


### PR DESCRIPTION
This reduce some variable scope.
The second commit clear an error we get on launch, if the logging directory doesn't exist yet, an error is trigger in the get available size call.
```
mavlink-router version v2-147-g02bc8b3+
Opened TCP Client [4]to_SITL: 127.0.0.1:5762
[Log Deletion] Error when measuring free disk space: No such file or directory
Logging target system_id=1 on 00000-2021-12-29_20-26-46.bin
```
The patch is done by simply check for the directory before checking for size.