### PR TITLE
Mitigate binlog storm issue

### DIFF
--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -224,3 +224,25 @@ void BinLog::_restart()
     stop();
     start();
 }
+
+bool BinLog::_alive_timeout()
+{
+    if (_timeout_write_total == _stat.write.total) {
+        // we probably just got FMT plus a MODE change
+        // https://github.com/ArduPilot/ardupilot/blame/7b5ab8bb8cfd6fded545beb49585c54b38b04999/libraries/AP_Logger/AP_Logger_Backend.cpp#L454
+        if (_last_acked_seqno > 400) {
+            log_warning("No Log messages received in %u seconds restarting Log...", ALIVE_TIMEOUT);
+            stop();
+            start();
+        } else {
+            // silent restart
+            LogEndpoint::_delete_last_log();
+            stop();
+            start();
+        }
+
+    }
+
+    _timeout_write_total = _stat.write.total;
+    return true;
+}

--- a/src/binlog.h
+++ b/src/binlog.h
@@ -42,6 +42,7 @@ protected:
     bool _logging_start_timeout() override;
 
     const char *_get_logfile_extension() override { return "bin"; };
+    bool _alive_timeout() override;
 
 private:
     uint32_t _last_acked_seqno = 0;

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -41,7 +41,6 @@
 
 #include "mainloop.h"
 
-#define ALIVE_TIMEOUT 5
 #define MAX_RETRIES   10
 
 const ConfFile::OptionsTable LogEndpoint::option_table[] = {

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -125,6 +125,23 @@ void LogEndpoint::mark_unfinished_logs()
     closedir(dir);
 }
 
+void LogEndpoint::_delete_last_log()
+{
+    fsync(_file);
+    close(_file);
+    char log_file[PATH_MAX];
+    if (snprintf(log_file, sizeof(log_file), "%s/%s", _config.logs_dir.c_str(), _filename)
+        < (int)sizeof(log_file)) {
+        int err_code = remove(log_file);
+        if (err_code != 0) {
+            log_error("[Log Deletion] Error deleting last logfile %s: %m", _filename);
+        } else {
+            log_error("[Log Deletion] %s", _filename);
+        }
+    }
+
+}
+
 void LogEndpoint::_delete_old_logs()
 {
 

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -77,6 +77,7 @@ protected:
     } _timeout;
     uint32_t _timeout_write_total = 0;
     aiocb _fsync_cb = {};
+    static constexpr uint8_t ALIVE_TIMEOUT = 5;
 
     virtual const char *_get_logfile_extension() = 0;
 

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -92,6 +92,7 @@ protected:
     void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
                                  uint8_t source_component_id, const uint8_t *payload);
 
+    void _delete_last_log();
 private:
     int _get_file(const char *extension);
     static uint32_t _get_prefix(DIR *dir);


### PR DESCRIPTION
This provide a way to mitigate the issue with ArduPilot binlog.
The issue is that if we arm an ArduPilot vehicle and disarm, every 15s the binlog will end and a new one will start. This lead to generate a lot of mostly empty logs. 
This comes from ArduPilot, https://github.com/ArduPilot/ardupilot/blame/7b5ab8bb8cfd6fded545beb49585c54b38b04999/libraries/AP_Logger/AP_Logger_Backend.cpp#L454
ArduPilot logging log critical change after disarm and push the log on all Log Backend including Mavlink
The critical change are small: 1 state message or 1 mode change and the logging FMT.
We don't have way to filters those. 
The proposed change detect a small log (< 400msg, current FMT is at more than 300msg), and instead of just closing it to create a new one, delete it as it doesn't got anything useful.

The issue could be simply test by using sitl and setting LOG_BACKEND_TYPE 3, reboot, arm, and wait auto disarm.