### PR TITLE
ci: enable Werror

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
           if [ "${{ matrix.name }}" == "i686" ]; then
               sudo dpkg --add-architecture i386
               sudo apt-get update
-              sudo apt-get install --yes pkg-config gcc-multilib g++-multilib libgtest-dev:i386
+              sudo apt-get install --yes libgtest-dev:i386
           fi
-          sudo apt-get install --yes ninja-build python3-pip libgtest-dev
+          sudo apt-get install --yes pkg-config gcc-multilib g++-multilib ninja-build python3-pip libgtest-dev
           pip3 install meson pymavlink
       - name: install dependencies (cross)
         if: ${{ matrix.arch != 'native' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
             arch: aarch64-linux-gnu
           - name: native
             arch: native
-          - name: m32
+          - name: i686
             arch: native
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: install dependencies (native)
         if: ${{ matrix.arch == 'native' }}
         run: |
-          if [ "${{ matrix.name }}" == "m32" ]; then
+          if [ "${{ matrix.name }}" == "i686" ]; then
               sudo dpkg --add-architecture i386
               sudo apt-get update
               sudo apt-get install --yes pkg-config gcc-multilib g++-multilib libgtest-dev:i386
@@ -48,11 +48,10 @@ jobs:
       - name: configure (native)
         if: ${{ matrix.arch == 'native' }}
         run: |
-          if [ "${{ matrix.name }}" == "m32" ]; then
-              export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
-              export CXXFLAGS=-m32
-              export CFLAGS=-m32
-              meson setup --werror --libdir i386-linux-gnu -Dsystemdsystemunitdir=/usr/lib/systemd/system build-${{ matrix.name }} .
+          export PKG_CONFIG=$PWD/tools/meson-native-ubuntu-pkg-config
+          if [ "${{ matrix.name }}" == "i686" ]; then
+              export PATH="$PWD/tools:$PATH"
+              meson setup --werror --cross-file meson-cross-i686.ini  -Dsystemdsystemunitdir=/usr/lib/systemd/system build-${{ matrix.name }} .
           else
               meson setup --werror build-${{ matrix.name }} .
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,13 @@ jobs:
               export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
               export CXXFLAGS=-m32
               export CFLAGS=-m32
-              meson setup --libdir i386-linux-gnu -Dsystemdsystemunitdir=/usr/lib/systemd/system build-${{ matrix.name }} .
+              meson setup --werror --libdir i386-linux-gnu -Dsystemdsystemunitdir=/usr/lib/systemd/system build-${{ matrix.name }} .
           else
-              meson setup build-${{ matrix.name }} .
+              meson setup --werror build-${{ matrix.name }} .
           fi
       - name: configure (cross)
         if: ${{ matrix.arch != 'native' }}
-        run: meson setup -Dsystemdsystemunitdir=/usr/lib/systemd/system --cross-file meson-cross-${{ matrix.name }}.ini --cross-file meson-cross-sysroot.ini build-${{ matrix.name }} .
+        run: meson setup --werror -Dsystemdsystemunitdir=/usr/lib/systemd/system --cross-file meson-cross-${{ matrix.name }}.ini --cross-file meson-cross-sysroot.ini build-${{ matrix.name }} .
 
       - name: build
         run: ninja -C build-${{ matrix.name }}
@@ -87,7 +87,7 @@ jobs:
           submodules: recursive
 
       - name: configure
-        run: meson setup -Dsystemdsystemunitdir=/usr/lib/systemd/system build .
+        run: meson setup --werror -Dsystemdsystemunitdir=/usr/lib/systemd/system build .
 
       - name: build
         run: ninja -C build

--- a/meson-cross-i686.ini
+++ b/meson-cross-i686.ini
@@ -1,0 +1,18 @@
+[binaries]
+c = 'gcc'
+cpp = 'g++'
+ar = 'gcc-ar'
+strip = 'strip'
+pkgconfig = 'meson-i686-ubuntu-pkg-config'
+
+[built-in options]
+c_args = ['-m32']
+c_link_args = ['-m32']
+cpp_args = ['-m32']
+cpp_link_args = ['-m32']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'i686'
+endian = 'little'

--- a/tools/meson-i686-ubuntu-pkg-config
+++ b/tools/meson-i686-ubuntu-pkg-config
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec i686-linux-gnu-pkg-config --define-variable=prefix=/usr "$@"

--- a/tools/meson-native-ubuntu-pkg-config
+++ b/tools/meson-native-ubuntu-pkg-config
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec pkg-config --define-variable=prefix=/usr "$@"


### PR DESCRIPTION
In general I think -Werror can't be the default due to different
compilers being used. However, for CI it's good to enable it because we
control the exact version we are using.

Enable -Werror to avoid introducing warnings.