### PR TITLE
Add optional message de-duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ Message filters:
   - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
     compoent IDs to be sent via this endpoint
 
+Message de-duplication:
+
+  - If enabled, each incoming message is checked, whether another copy was
+    already received the last `DeduplicationPeriod` milliseconds ago. If it's
+    already known, the message will be dropped as it was never received and the
+    timeout counter for that message will be reset. Messages are identified via
+    their `std::hash` value.
+
 ### Flight Stack Logging
 
 Mavlink router can also collect flight stack logs. It supports collecting both

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -33,6 +33,12 @@
 # Default: <info>
 #DebugLogLevel = info
 
+# Enable de-duplication of incoming messages. If a message is received another
+# time in the configured time period (in milliseconds), it will be dropped. The
+# second message will reset the timer.
+# Default: 0 (de-duplication disabled)
+#DeDuplicationPeriod = 0
+
 ## TCP Server Endpoints
 
 # Listen for TCP connections on this port. Set to 0 to disable.

--- a/src/dedup.cpp
+++ b/src/dedup.cpp
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the MAVLink Router project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dedup.h"
+
+#include <chrono>
+#include <queue>
+#include <string>
+#include <unordered_set>
+
+class DedupImpl {
+    using hash_t = uint64_t;
+    using time_t = uint32_t;
+
+public:
+    DedupImpl()
+        : _start_time(std::chrono::system_clock::now())
+    {
+    }
+
+    bool check_packet(const uint8_t *buffer, uint32_t size, uint32_t dedup_period_ms)
+    {
+        using namespace std::chrono;
+        time_t timestamp
+            = duration_cast<milliseconds>(std::chrono::system_clock::now() - _start_time).count();
+        // pop data from front queue, delete corresponding data from multiset
+        while (!_time_hash_queue.empty()
+               && timestamp > _time_hash_queue.front().first + dedup_period_ms) {
+            hash_t hash_to_delete = _time_hash_queue.front().second;
+            _packet_hash_set.erase(_packet_hash_set.find(hash_to_delete));
+            _time_hash_queue.pop();
+        }
+
+        // hash buffer
+        // TODO: with C++17 use a string_view instead, or use a custom hash function
+        _hash_buffer.assign((const char *)buffer, (uint64_t)size);
+        hash_t hash = std::hash<std::string>{}(_hash_buffer);
+
+        bool new_packet_hash = true;
+        if (_packet_hash_set.find(hash) == _packet_hash_set.end()) {
+            // add hash and timestamp to back of queue, and add hash to multiset
+            _packet_hash_set.insert(hash);
+            _time_hash_queue.emplace(timestamp, hash);
+        } else {
+            new_packet_hash = false;
+        }
+
+        return new_packet_hash;
+    }
+
+private:
+    const std::chrono::time_point<std::chrono::system_clock> _start_time;
+
+    std::queue<std::pair<time_t, hash_t>> _time_hash_queue;
+    std::unordered_set<hash_t> _packet_hash_set;
+    std::string _hash_buffer;
+};
+
+Dedup::Dedup(uint32_t dedup_period_ms)
+    : _dedup_period_ms(dedup_period_ms)
+    , _impl(new DedupImpl())
+{
+}
+
+Dedup::~Dedup()
+{
+    // explicit d-tor is needed to make the unique_ptr work even though it looks like a default d-tor
+}
+
+void Dedup::set_dedup_period(uint32_t dedup_period_ms)
+{
+    _dedup_period_ms = dedup_period_ms;
+}
+
+Dedup::PacketStatus Dedup::check_packet(const uint8_t *buffer, uint32_t size)
+{
+    // short circuit if disabled
+    if (_dedup_period_ms == 0) {
+        return PacketStatus::NEW_PACKET_OR_TIMED_OUT;
+    }
+
+    if (_impl->check_packet(buffer, size, _dedup_period_ms)) {
+        return PacketStatus::NEW_PACKET_OR_TIMED_OUT;
+    }
+    return PacketStatus::ALREADY_EXISTS_IN_BUFFER;
+}

--- a/src/dedup.h
+++ b/src/dedup.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the MAVLink Router project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+class DedupImpl;
+
+/*
+ * De-duplication of raw buffers.
+ *
+ * When presented with a buffer, this class calculates a hash value of the
+ * data and determines whether that hash was already seen in a configureable
+ * time period (dedup_period). A known hash value will reset the time for that
+ * value. Old hash values will be cleaned up each time check_packet is called.
+ *
+ * A dedup_period of 0 will disable all de-duplication checks.
+ */
+class Dedup {
+public:
+    enum class PacketStatus { NEW_PACKET_OR_TIMED_OUT, ALREADY_EXISTS_IN_BUFFER };
+
+    Dedup(uint32_t dedup_period_ms = 0);
+    ~Dedup();
+
+    void set_dedup_period(uint32_t dedup_period_ms);
+
+    PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
+
+private:
+    uint32_t _dedup_period_ms; ///< how long
+    std::unique_ptr<DedupImpl> _impl;
+};

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -247,7 +247,7 @@ int Endpoint::read_msg(struct buffer *pbuf)
             return r;
         }
 
-        log_debug("%s [%d]%s: got %zd bytes", _type.c_str(), fd, _name.c_str(), r);
+        log_debug("> %s [%d]%s: Got %zd bytes", _type.c_str(), fd, _name.c_str(), r);
         rx_buf.len += r;
     }
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -149,6 +149,8 @@ public:
     void filter_add_allowed_msg_id(uint32_t msg_id) { _allowed_msg_ids.push_back(msg_id); }
     void filter_add_allowed_src_comp(uint8_t src_comp) { _allowed_src_comps.push_back(src_comp); }
 
+    bool allowed_by_dedup(const buffer *pbuf) const;
+
     std::string get_type() const { return this->_type; }
 
     struct buffer rx_buf;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -406,9 +406,10 @@ static int parse_confs(ConfFile &conffile, Configuration &config)
     struct ConfFile::section_iter iter;
     // clang-format off
     static const ConfFile::OptionsTable global_option_table[] = {
-        {"TcpServerPort",   false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(Configuration, tcp_port)},
-        {"ReportStats",     false, ConfFile::parse_bool,    OPTIONS_TABLE_STRUCT_FIELD(Configuration, report_msg_statistics)},
-        {"DebugLogLevel",   false, parse_log_level,         OPTIONS_TABLE_STRUCT_FIELD(Configuration, debug_log_level)},
+        {"TcpServerPort",       false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(Configuration, tcp_port)},
+        {"ReportStats",         false, ConfFile::parse_bool,    OPTIONS_TABLE_STRUCT_FIELD(Configuration, report_msg_statistics)},
+        {"DebugLogLevel",       false, parse_log_level,         OPTIONS_TABLE_STRUCT_FIELD(Configuration, debug_log_level)},
+        {"DeduplicationPeriod", false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(Configuration, dedup_period_ms)},
         {}
     };
     // clang-format on

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -352,6 +352,12 @@ static bool _print_statistics_timeout_cb(void *data)
     return true;
 }
 
+bool Mainloop::dedup_check_msg(const buffer *buf)
+{
+    return _msg_dedup.check_packet(buf->data, buf->len)
+        == Dedup::PacketStatus::NEW_PACKET_OR_TIMED_OUT;
+}
+
 bool Mainloop::add_endpoints(const Configuration &config)
 {
     // Create UART and UDP endpoints
@@ -420,6 +426,11 @@ bool Mainloop::add_endpoints(const Configuration &config)
     // Apply other options
     if (config.report_msg_statistics) {
         add_timeout(MSEC_PER_SEC, _print_statistics_timeout_cb, this);
+    }
+
+    if (config.dedup_period_ms > 0) {
+        log_info("Message de-duplication enabled: %ld ms period", config.dedup_period_ms);
+        _msg_dedup.set_dedup_period(config.dedup_period_ms);
     }
 
     return true;

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ exe_mavlink_router = executable('mavlink-routerd',
         [
          'autolog.cpp',
          'binlog.cpp',
+         'dedup.cpp',
          'endpoint.cpp',
          'git_version.cpp',
          'logendpoint.cpp',
@@ -29,6 +30,7 @@ if dep_gtest.found()
           [
             'autolog.cpp',
             'binlog.cpp',
+            'dedup.cpp',
             'endpoint.cpp',
             'logendpoint.cpp',
             'mainloop.cpp',
@@ -52,6 +54,7 @@ if dep_gtest.found()
           [
             'autolog.cpp',
             'binlog.cpp',
+            'dedup.cpp',
             'endpoint.cpp',
             'endpoints_test.cpp',
             'logendpoint.cpp',


### PR DESCRIPTION
As discussed in #240, parallel data links have some special needs. One of which is de-duplication of incoming messages.

This implementation has been used for some time and works just fine. I just needed to make some changes to make it compatible with the latest master, squashed some of Julian's commits and added some comments on the behavior.