### PR TITLE
Fix wrong error message about disk space

### DIFF
--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -143,10 +143,15 @@ void LogEndpoint::_delete_old_logs()
 
     if (statvfs(_config.logs_dir.c_str(), &buf) == 0) {
         free_space = (uint64_t)buf.f_bsize * buf.f_bavail;
+    } else if (errno == ENOENT) {
+        // Ignore error - we don't have any logs to delete if directory
+        // doesn't exist
+        return;
     } else {
         free_space = UINT64_MAX;
         log_error("[Log Deletion] Error when measuring free disk space: %m");
     }
+
     log_debug("[Log Deletion]  Total free space: %" PRIu64 "MB. Min free space: %luMB",
               free_space / (1ul << 20),
               _config.min_free_space / (1ul << 20));


### PR DESCRIPTION
This prevents error on launch if the directory doesn't exist yet.

    mavlink-router version v2-147-g02bc8b3+
    Opened TCP Client [4]to_SITL: 127.0.0.1:5762
    [Log Deletion] Error when measuring free disk space: No such file or
    directory
    Logging target system_id=1 on 00000-2021-12-29_20-26-46.bin

Simply ignore the error if errno == ENOENT: we don't need to cleanup
anything if the directory doesn't even exist.

This is an alternative minimal fix to the proposed in #317 by Pierre
Kancir.