### PR TITLE
Support redundant data links: Endpoint groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ Message filters:
   - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
     compoent IDs to be sent via this endpoint
 
+Endpoint groups:
+
+  - Multiple endpoints can be configured to be in the same endpoin group.
+    Endpoints in the same group will share the same list of connected systems.  
+    When using two (or more) **parallel data links**, e.g. LTE and telemetry
+    radio, the endpoint **must** be grouped on both sides. Otherwise one link
+    will not be used any more because of routing rule 1.
+
 ### Flight Stack Logging
 
 Mavlink router can also collect flight stack logs. It supports collecting both

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -105,6 +105,13 @@
 # Default: Empty list (disabled)
 #AllowSrcCompOut = 
 
+# Group parallel/ redundant data links to use the same list of connected
+# systems. This is needed to prevent messages from one of the parallel links
+# being send back on the other one right away.
+# Set the same name (arbitrary string) on multiple endpoints to group them.
+# Default: Empty (no group)
+#Group = 
+
 ## Example
 [UartEndpoint alpha]
 Device = /dev/ttyS0

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -43,6 +43,7 @@ struct UartEndpointConfig {
     bool flowcontrol{false};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::string group;
 };
 
 struct UdpEndpointConfig {
@@ -54,6 +55,7 @@ struct UdpEndpointConfig {
     Mode mode;
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::string group;
 };
 
 struct TcpEndpointConfig {
@@ -63,6 +65,7 @@ struct TcpEndpointConfig {
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::string group;
 };
 
 /*
@@ -149,7 +152,10 @@ public:
     void filter_add_allowed_msg_id(uint32_t msg_id) { _allowed_msg_ids.push_back(msg_id); }
     void filter_add_allowed_src_comp(uint8_t src_comp) { _allowed_src_comps.push_back(src_comp); }
 
+    void link_group_member(std::shared_ptr<Endpoint> other);
+
     std::string get_type() const { return this->_type; }
+    std::string get_group_name() const { return this->_group_name; };
 
     struct buffer rx_buf;
     struct buffer tx_buf;
@@ -163,6 +169,9 @@ protected:
     const std::string _type; ///< UART, UDP, TCP, Log
     std::string _name;       ///< Endpoint name from config file
     size_t _last_packet_len = 0;
+
+    std::string _group_name{}; // empty name to disable endpoint groups
+    std::vector<std::shared_ptr<Endpoint>> _group_members{};
 
     // Statistics
     struct {

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -390,6 +390,19 @@ bool Mainloop::add_endpoints(const Configuration &config)
         g_endpoints.emplace_back(tcp);
     }
 
+    // Link grouped endpoints together
+    for (auto e : g_endpoints) {
+        if (e->get_group_name().empty()) {
+            continue;
+        }
+
+        for (auto other : g_endpoints) { // find other endpoints in group
+            if (other != e && e->get_group_name() == e->get_group_name()) {
+                e->link_group_member(other);
+            }
+        }
+    }
+
     // Create TCP server
     if (config.tcp_port != 0u) {
         g_tcp_fd = tcp_open(config.tcp_port);


### PR DESCRIPTION
As discussed in #240, parallel/ redundant data links will lead to one link not being used any more with the current routing rules. Since mavlink-router can not determine the network topology by itself, it has to be provided in the configuration.

The list of connected systems should be the same on all of the endpoints terminating the parallel data links. If that's the case, routing rule 1 (don't send data on an endpoint, if it's source system is connected on that endpoint) should prevent data being received on one of the grouped endpoint to be sent via all other group members.

A hierarchical structure of endpoints (GroupEndpoint containing the group members) would probably be a cleaner solution. But this should work as a proof of concept and doesn't change too much of the general routing architecture.