### PR TITLE
CI: Upload cross-compiled artifacts as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
             arch: arm-linux-gnueabihf
           - name: aarch64
             arch: aarch64-linux-gnu
-          - name: native
+          - name: x86_64
             arch: native
           - name: i686
             arch: native
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: 0  # otherwise the version header just contains the commit hash
 
       - name: install dependencies (native)
         if: ${{ matrix.arch == 'native' }}
@@ -73,6 +74,21 @@ jobs:
         if: ${{ matrix.arch == 'native' }}
         run: ./tests/routing_test.py -b ./build-${{ matrix.name }}/src/mavlink-routerd
 
+      - uses: actions/upload-artifact@master
+        with:
+          path: build-${{ matrix.name }}/src/mavlink-routerd
+          name: mavlink-routerd-glibc-${{ matrix.name }}
+      - uses: svenstaro/upload-release-action@v2
+        name: Upload binaries to release
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build-${{ matrix.name }}/src/mavlink-routerd
+          asset_name: mavlink-routerd-glibc-${{ matrix.name }}
+          tag: ${{ github.ref }}
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+          overwrite: true
+
   alpine-linux:
     name: alpine 3.14 (musl)
     runs-on: ubuntu-20.04
@@ -84,6 +100,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: 0  # otherwise the version header just contains the commit hash
 
       - name: configure
         run: meson setup --werror -Dsystemdsystemunitdir=/usr/lib/systemd/system build .
@@ -97,6 +114,7 @@ jobs:
       - uses: actions/upload-artifact@master
         with:
           path: build/src/mavlink-routerd-musl-x86-64
+          name: mavlink-routerd-musl-x86-64
       - uses: svenstaro/upload-release-action@v2
         name: Upload binaries to release
         if: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Currently only the result of the alpine linux 64 bit build is uploaded as a build artifact, in action runs as well as releases. Especially for the releases, I think we should provide the cross-compiled builds as well.  
(Unfortunately it doesn't solve cross-compiling for my board since my yocto linux glibc is too old. But I'm not sure, if we want to support legacy systems as well.)

This PR also fixes an issue with the version number that's automatically included in the build and displayed in the log messages during startup. Since the git tags are used for this version number, a shallow clone as it's done by default just gets us the commit hash and no "nice" version number.