### PR TITLE
Add support for unix domain sockets to TCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ config file format):
       incoming message was received.
   - TCP Client:
     * Configuration: Target IP address and port, reconnection interval in case
-      of disconnection
-    * Behavior: Data is received and sent right after the TCP session is
-      established
+      of disconnection  
+      Alternately a unix domain socket path can be used as address, the port
+      will be ignored in that case.
+    * Behavior: Data is received and sent right after the TCP (or unix domain
+      socket) session is established 
 
 Defining endpoints:
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -156,6 +156,7 @@ Port = 11000
 
 # Server IP address to connect to.
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
+# Unix domain sockets paths must begin at root (start wtih a `/`).
 # Mandatory, no default value
 #Address = 
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <string>
+#include <sys/un.h>
 #include <utility>
 #include <vector>
 
@@ -276,6 +277,7 @@ protected:
     bool open(const std::string &ip, unsigned long port);
     static int open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr);
     static int open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6);
+    static int open_socket(const char *ip, sockaddr_un &sockaddr);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
@@ -288,7 +290,9 @@ private:
     bool _valid = true;
 
     bool is_ipv6;
+    bool is_unix_socket;
     int _retry_timeout = 0; // disable retry by default
     struct sockaddr_in sockaddr;
     struct sockaddr_in6 sockaddr6;
+    struct sockaddr_un sockaddr_un;
 };


### PR DESCRIPTION
Quick stab at implementing unix domain socket support. I deliberately wanted to use a `SOCK_STREAM` instead of `SOCK_DGRAM` to have bi-directional communication from the start on. (Somehow it didn't work with datagram first.)

I extended the TCP endpoint because I wanted to have the re-connect logic. Somehow it sending didn't work using `sendto` because of "Transport endpoint is already connected".

The code is not great, but may be a starting point.