### PR TITLE
mainloop: Fix UdpEndpoint destructor double free

### DIFF
--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -310,6 +310,8 @@ int Mainloop::loop()
         _log_endpoint->stop();
     }
 
+    clear_endpoints();
+
     // free all remaning Timeouts
     while (_timeouts != nullptr) {
         Timeout *current = _timeouts;
@@ -421,6 +423,11 @@ bool Mainloop::add_endpoints(const Configuration &config)
     }
 
     return true;
+}
+
+void Mainloop::clear_endpoints()
+{
+    g_endpoints.clear();
 }
 
 int Mainloop::tcp_open(unsigned long tcp_port)

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -63,6 +63,7 @@ public:
     void mod_timeout(Timeout *t, uint32_t timeout_msec);
 
     bool add_endpoints(const Configuration &config);
+    void clear_endpoints();
 
     void print_statistics();
 


### PR DESCRIPTION
When we run the destructor of the endpoints we will alread have deleted
all the timeouts. The idea of cleaning up the timeouts inside the
mainloop is just because we don't want to leak anything. However each
component should clean up after itself.

This fix the following valgrind trace:

== Invalid write of size 1
==374140==    at 0x113F1A: UdpEndpoint::~UdpEndpoint() (endpoint.cpp:913)
==374140==    by 0x4ECCC9F: ???
==374140==    by 0x131C1E: _M_release (shared_ptr_base.h:168)
==374140==    by 0x131C1E: ~__shared_count (shared_ptr_base.h:702)
==374140==    by 0x131C1E: ~__shared_ptr (shared_ptr_base.h:1149)
==374140==    by 0x131C1E: ~shared_ptr (shared_ptr.h:122)
==374140==    by 0x131C1E: _Destroy<std::shared_ptr<Endpoint> > (stl_construct.h:140)
==374140==    by 0x131C1E: __destroy<std::shared_ptr<Endpoint>*> (stl_construct.h:152)
==374140==    by 0x131C1E: _Destroy<std::shared_ptr<Endpoint>*> (stl_construct.h:185)
==374140==    by 0x131C1E: _Destroy<std::shared_ptr<Endpoint>*, std::shared_ptr<Endpoint> > (alloc_traits.h:746)
==374140==    by 0x131C1E: ~vector (stl_vector.h:680)
==374140==    by 0x131C1E: Mainloop::~Mainloop() (mainloop.h:50)
==374140==    by 0x4B284A6: __run_exit_handlers (in /usr/lib/libc-2.33.so)
==374140==    by 0x4B2864D: exit (in /usr/lib/libc-2.33.so)
==374140==    by 0x4B10B2B: (below main) (in /usr/lib/libc-2.33.so)
==374140==  Address 0x4eccbbc is 12 bytes inside a block of size 64 free'd
==374140==    at 0x48418AF: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==374140==    by 0x13152A: Mainloop::loop() (mainloop.cpp:318)
==374140==    by 0x1108A2: main (main.cpp:615)
==374140==  Block was alloc'd at
==374140==    at 0x483F013: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==374140==    by 0x12F94D: Mainloop::add_timeout(unsigned int, std::function<bool (void*)>, void const*) (mainloop.cpp:466)
==374140==    by 0x11513C: UdpEndpoint::open(char const*, unsigned long, UdpEndpointConfig::Mode) (endpoint.cpp:1051)
==374140==    by 0x1175D2: UdpEndpoint::setup(UdpEndpointConfig) (endpoint.cpp:923)
==374140==    by 0x1300B2: Mainloop::add_endpoints(Configuration const&) (mainloop.cpp:371)
==374140==    by 0x110892: main (main.cpp:611)