### PR TITLE
TCP endpoint: Reject message when not connected

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -1525,6 +1525,17 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
     return r;
 }
 
+Endpoint::AcceptState TcpEndpoint::accept_msg(const struct buffer *pbuf) const
+{
+    // reject when TCP endpoint is not connected (but trying to re-connect)
+    if (this->fd == -1) {
+        return Endpoint::AcceptState::Rejected;
+    }
+
+    // otherwise: refer to standard accept rules
+    return Endpoint::accept_msg(pbuf);
+}
+
 void TcpEndpoint::close()
 {
     if (fd > -1) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -268,6 +268,8 @@ public:
     bool is_valid() override { return _valid; };
     bool is_critical() override { return false; };
 
+    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const;
+
     int accept(int listener_fd);        ///< accept incoming connection
     bool setup(TcpEndpointConfig conf); ///< open connection and apply config
     bool reopen();                      ///< re-try connecting to the server


### PR DESCRIPTION
Just a small fix of the error messages to be less confusing. Otherwise you'll get "Trying to write invalid fd" on a TcpEndpoint which was connected once, but then lost it's socket connection.

Steps to reproduce:
1. Add a TcpEndpoint to the config (e.g. to another mavlink-router) and a connection to a FMU (to generate telemetry data)
2. Start mavlink-router while the server to connect to is also started
3. Stop the server
4. See many "Trying to write invalid fd" errors until the server is started again

I suppressed the error message in `TcpEndpoint::write_msg()` first, but then thought, that rejecting the message in `Endpoint::accept_msg()` is actually nicer even though it introduces a very special condition to the previously generic `accept_msg` method.