### PR TITLE
Sniffer function added

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ Message de-duplication:
     timeout counter for that message will be reset. Messages are identified via
     their `std::hash` value.
 
+Message Sniffing:
+
+  - A Sniffer can be defined by setting SnifferSysID. This will forward all traffic
+    to endpoints on which this MAVLink system ID is connected. This can be used to
+    log or view all messages flowing though mavlink-router.
+
 ### Flight Stack Logging
 
 Mavlink router can also collect flight stack logs. It supports collecting both

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -22,7 +22,8 @@
 ## General Configuration
 ##
 
-[General] # this section only has one instance and therefore no name
+[General]
+# this section only has one instance and therefore no name
 
 # Print traffic statistics to stdout
 # Default: <false>
@@ -78,6 +79,12 @@
 # disable this functionality.
 # Default: 0 (disabled)
 #MaxLogFiles = 0
+
+# SnifferSysid
+# Forward all traffic to endpoints on which this MAVLink system ID is connected.
+# This can be used to log or view all messages flowing though mavlink-router.
+# Default: 0 (disabled)
+#SnifferSysid=254
 
 
 ##

--- a/examples/heartbeat-print.cpp
+++ b/examples/heartbeat-print.cpp
@@ -53,7 +53,8 @@ static void handle_new_message(const mavlink_message_t *msg)
         printf("HEARTBEAT:\n"
                "\tmavlink_version: %u\n"
                "\ttype: %u\n",
-               heartbeat.mavlink_version, heartbeat.type);
+               heartbeat.mavlink_version,
+               heartbeat.type);
     }
 }
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -156,6 +156,10 @@ public:
     struct buffer rx_buf;
     struct buffer tx_buf;
 
+    // An endpoint with this system id becomes a "sniffer" and all
+    // messages are accepted.
+    static uint16_t sniffer_sysid;
+
 protected:
     virtual int read_msg(struct buffer *pbuf);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,9 +51,10 @@ static const struct option long_options[] = {{"endpoints", required_argument, nu
                                              {"debug-log-level", required_argument, nullptr, 'g'},
                                              {"verbose", no_argument, nullptr, 'v'},
                                              {"version", no_argument, nullptr, 'V'},
+                                             {"sniffer-sysid", required_argument, nullptr, 's'},
                                              {}};
 
-static const char *short_options = "he:rt:c:d:l:p:g:vV";
+static const char *short_options = "he:rt:c:d:l:p:g:vV:s:";
 
 static void help(FILE *fp)
 {
@@ -81,6 +82,7 @@ static void help(FILE *fp)
         "                               <error|warning|info|debug>\n"
         "  -v --verbose                 Verbose. Same as --debug-log-level=debug\n"
         "  -V --version                 Show version\n"
+        "  -s --sniffer-sysid           Sysid that all messages are sent to.\n"
         "  -h --help                    Print this message\n",
         program_invocation_short_name);
 }
@@ -239,6 +241,16 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
         }
         case 'v': {
             config.debug_log_level = Log::Level::DEBUG;
+            break;
+        }
+        case 's': {
+            uint16_t id = atoi(optarg);
+            if ((id == 0) || (id > 255)) {
+                log_error("Invalid sniffer sysid %s", optarg);
+                help(stderr);
+                return -EINVAL;
+            }
+            config.sniffer_sysid = id;
             break;
         }
         case 'p': {
@@ -410,6 +422,7 @@ static int parse_confs(ConfFile &conffile, Configuration &config)
         {"ReportStats",         false, ConfFile::parse_bool,    OPTIONS_TABLE_STRUCT_FIELD(Configuration, report_msg_statistics)},
         {"DebugLogLevel",       false, parse_log_level,         OPTIONS_TABLE_STRUCT_FIELD(Configuration, debug_log_level)},
         {"DeduplicationPeriod", false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(Configuration, dedup_period_ms)},
+        {"SnifferSysid",    false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(Configuration, sniffer_sysid)},
         {}
     };
     // clang-format on

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -361,6 +361,11 @@ bool Mainloop::dedup_check_msg(const buffer *buf)
 bool Mainloop::add_endpoints(const Configuration &config)
 {
     // Create UART and UDP endpoints
+    if (config.sniffer_sysid != 0) {
+        log_info("An endpoint with sysid %u on it will sniff all messages",
+                 Endpoint::sniffer_sysid);
+        Endpoint::sniffer_sysid = config.sniffer_sysid;
+    }
     for (const auto &conf : config.uart_configs) {
         auto uart = std::make_shared<UartEndpoint>(conf.name);
 

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -42,6 +42,7 @@ struct Configuration {
     std::vector<UartEndpointConfig> uart_configs;
     std::vector<UdpEndpointConfig> udp_configs;
     std::vector<TcpEndpointConfig> tcp_configs;
+    unsigned long sniffer_sysid;
 };
 
 struct endpoint_entry {


### PR DESCRIPTION
Hello Maintainer of mavlink-router!

I added a sniffer function to mavllink-router.

The user can choose a Mavlink system-id that all messages are forwarded to. This is useful for real time debugging. One can choose his favorite mavlink inspector (Missionplanner and QGroundcontrol have nice ones...) and observe all Mavlink traffic.

You can leave this option on permanently with sys-id=254 for example, and whenever you wand to see what's going on just change you GCS id to 254 or connect with another GCS with this id.

I found this useful, so I added command line and configuration file functionality, so everyone can use it. 
Remark: Even on sniffer endpoint filters apply and messages are not echoed back.

Cheers,
-Guy
 