### PR TITLE
Support redundant data links: Endpoint groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ Message de-duplication:
     timeout counter for that message will be reset. Messages are identified via
     their `std::hash` value.
 
+Endpoint groups:
+
+  - Multiple endpoints can be configured to be in the same endpoin group.
+    Endpoints in the same group will share the same list of connected systems.  
+    When using two (or more) **parallel data links**, e.g. LTE and telemetry
+    radio, the endpoint **must** be grouped on both sides. Otherwise one link
+    will not be used any more because of routing rule 1.
+
 Message Sniffing:
 
   - A Sniffer can be defined by setting SnifferSysID. This will forward all traffic

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -118,6 +118,13 @@
 # Default: Empty list (disabled)
 #AllowSrcCompOut = 
 
+# Group parallel/ redundant data links to use the same list of connected
+# systems. This is needed to prevent messages from one of the parallel links
+# being send back on the other one right away.
+# Set the same name (arbitrary string) on multiple endpoints to group them.
+# Default: Empty (no group)
+#Group = 
+
 ## Example
 [UartEndpoint alpha]
 Device = /dev/ttyS0

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -62,6 +62,7 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"FlowControl",     false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
     {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_out)},
+    {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
 
@@ -73,6 +74,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
+    {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
 
@@ -83,6 +85,7 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
+    {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
 // clang-format on
@@ -429,6 +432,11 @@ void Endpoint::_add_sys_comp_id(uint8_t sysid, uint8_t compid)
                  fd);
     }
     _sys_comp_ids.push_back(sys_comp_id);
+
+    // add to grouped endpoints as well
+    for (auto e : _group_members) {
+        e->_add_sys_comp_id(sysid, compid);
+    }
 }
 
 bool Endpoint::has_sys_id(unsigned sysid) const
@@ -516,6 +524,17 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
 bool Endpoint::allowed_by_dedup(const buffer *buf) const
 {
     return Mainloop::get_instance().dedup_check_msg(buf);
+}
+
+void Endpoint::link_group_member(std::shared_ptr<Endpoint> other)
+{
+    if (_group_name.empty() || other->get_group_name() != _group_name) {
+        return;
+    }
+
+    _group_members.push_back(other);
+
+    log_info("Grouped %s with %s", other->_name.c_str(), _name.c_str());
 }
 
 bool Endpoint::_check_crc(const mavlink_msg_entry_t *msg_entry) const
@@ -641,6 +660,8 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_src_comp(src_comp);
     }
+
+    this->_group_name = conf.group;
 
     return true;
 }
@@ -967,6 +988,8 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_src_comp(src_comp);
     }
+
+    this->_group_name = conf.group;
 
     return true;
 }
@@ -1307,6 +1330,8 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_src_comp(src_comp);
     }
+
+    this->_group_name = conf.group;
 
     if (!this->open(conf.address, conf.port)) {
         log_warning("Could not open %s:%ld, re-trying every %d sec",

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -43,6 +43,7 @@ struct UartEndpointConfig {
     bool flowcontrol{false};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::string group;
 };
 
 struct UdpEndpointConfig {
@@ -54,6 +55,7 @@ struct UdpEndpointConfig {
     Mode mode;
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::string group;
 };
 
 struct TcpEndpointConfig {
@@ -63,6 +65,7 @@ struct TcpEndpointConfig {
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::string group;
 };
 
 /*
@@ -151,7 +154,10 @@ public:
 
     bool allowed_by_dedup(const buffer *pbuf) const;
 
+    void link_group_member(std::shared_ptr<Endpoint> other);
+
     std::string get_type() const { return this->_type; }
+    std::string get_group_name() const { return this->_group_name; };
 
     struct buffer rx_buf;
     struct buffer tx_buf;
@@ -169,6 +175,9 @@ protected:
     const std::string _type; ///< UART, UDP, TCP, Log
     std::string _name;       ///< Endpoint name from config file
     size_t _last_packet_len = 0;
+
+    std::string _group_name{}; // empty name to disable endpoint groups
+    std::vector<std::shared_ptr<Endpoint>> _group_members{};
 
     // Statistics
     struct {

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -401,6 +401,19 @@ bool Mainloop::add_endpoints(const Configuration &config)
         g_endpoints.emplace_back(tcp);
     }
 
+    // Link grouped endpoints together
+    for (auto e : g_endpoints) {
+        if (e->get_group_name().empty()) {
+            continue;
+        }
+
+        for (auto other : g_endpoints) { // find other endpoints in group
+            if (other != e && e->get_group_name() == e->get_group_name()) {
+                e->link_group_member(other);
+            }
+        }
+    }
+
     // Create TCP server
     if (config.tcp_port != 0u) {
         g_tcp_fd = tcp_open(config.tcp_port);


### PR DESCRIPTION
When using multiple parallel (redundant) data links between two mavlink-router
instances, the loop prevention logic will effectively disable all but one of the
parallel links. This can be solved by having the endpoints of parallel link use
the same list of connected systems.

Rebased version of #330 