### PR TITLE
UART Endpoint: Speeds never returned success

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -98,9 +98,11 @@
 # Mandatory, no default value
 #Device = 
 
-# Baudrate of the device
+# List of baudrates to try to connect with the device. A default baud rate of
+# 115200 baud will always be added to the end of the list.
+# Format: Comma separated list of integers
 # Default: 115200
-#Baud = 115200
+#Baud = 57600
 
 # Enable flow control on device
 # Default: <false>

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -830,9 +830,11 @@ bool UartEndpoint::_change_baud_cb(void *data)
              _name.c_str(),
              _baudrates[_current_baud_idx]);
 
-    set_speed(_baudrates[_current_baud_idx]);
+    if (0 == set_speed(_baudrates[_current_baud_idx])) {
+        return false; // connection is fine now, no retry
+    }
 
-    return true;
+    return true; // try again
 }
 
 int UartEndpoint::read_msg(struct buffer *pbuf)
@@ -907,7 +909,9 @@ int UartEndpoint::add_speeds(const std::vector<speed_t> &bauds)
 
     _baudrates = bauds;
 
-    set_speed(_baudrates[0]);
+    if (set_speed(_baudrates[0]) == 0) {
+        return 0; // first baud rate worked, exit early
+    }
 
     _change_baud_timeout = Mainloop::get_instance().add_timeout(
         MSEC_PER_SEC * UART_BAUD_RETRY_SEC,


### PR DESCRIPTION
add_speeds and the change_baud_cb never set the return value correctly if the tried baud rate was successful.

We had some UART issues and wondered, how a `add_speeds()` has ever worked and not got stuck in an endless loop of callbacks. This seems way more logical (correct me, if I'm wrong).