### PR TITLE
TCP endpoint: Fix invalid write errors during reconnect

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -1522,8 +1522,8 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
     socklen_t addrlen;
 
     if (fd < 0) {
-        log_error("TCP %s: Trying to write invalid fd", _name.c_str());
-        return -EINVAL;
+        // skip this endpoint if not connected (e.g. during reconnect)
+        return 0;
     }
 
     /* TODO: send any pending data */


### PR DESCRIPTION
When a TCP endpoint detects an error, it schedules a reconnect (if not disabled). During the reconnection, the fd is invalid, but the endpoint still exists, so the write_msg() method is still called. But write_msg gives an error when the fd is invalid, even though this is expected as long as the reconnect attempts are running.