### PR TITLE
Complete the set of message filters: SysID filter and filtering incoming data

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,13 @@ Message filters:
   - AllowMsgIdOut: If set, only allow messages with the listed message IDs to
     be sent via this endpoint
   - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
-    compoent IDs to be sent via this endpoint
+    component IDs to be sent via this endpoint
+  - AllowMsgIdIn: If set, only allow messages with the listed message IDs to
+    be received on this endpoint. Since message ID 0 is not used, only allowing
+    this message ID can be used to block all incoming traffic on this endpoint,
+    e.g. to block interaction with the drone while still receiving telemetry.
+  - AllowSrcCompIn: If set, only allow messages from the listed MAVLink source
+    component IDs to be received on this endpoint
 
 Message de-duplication:
 

--- a/README.md
+++ b/README.md
@@ -233,12 +233,16 @@ Message filters:
     be sent via this endpoint
   - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
     component IDs to be sent via this endpoint
+  - AllowSrcSysOut: If set, only allow messages from the listed MAVLink source
+    systems to be sent via this endpoint
   - AllowMsgIdIn: If set, only allow messages with the listed message IDs to
     be received on this endpoint. Since message ID 0 is not used, only allowing
     this message ID can be used to block all incoming traffic on this endpoint,
     e.g. to block interaction with the drone while still receiving telemetry.
   - AllowSrcCompIn: If set, only allow messages from the listed MAVLink source
     component IDs to be received on this endpoint
+  - AllowSrcSysIn: If set, only allow messages from the listed MAVLink source
+    systems to be received on this endpoint
 
 Message de-duplication:
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -122,6 +122,12 @@
 # Default: Empty list (disabled)
 #AllowSrcCompOut = 
 
+# Only allow messages from the specified MAVLink source systems to be sent via
+# this endpoint. An empty list allows all source components.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#AllowSrcSysOut = 
+
 # Only allow specified MAVLink message IDs to be received on this endpoint.
 # An empty list allows all message IDs.
 # Format: Comma separated list of integers
@@ -133,6 +139,12 @@
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
 #AllowSrcCompIn = 
+
+# Only allow messages from the specified MAVLink source systems to be received
+# on this endpoint. An empty list allows all source components.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#AllowSrcSysIn = 
 
 # Group parallel/ redundant data links to use the same list of connected
 # systems. This is needed to prevent messages from one of the parallel links

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -122,6 +122,18 @@
 # Default: Empty list (disabled)
 #AllowSrcCompOut = 
 
+# Only allow specified MAVLink message IDs to be received on this endpoint.
+# An empty list allows all message IDs.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#AllowMsgIdIn = 
+
+# Only allow messages from the specified MAVLink source component IDs to be
+# received on this endpoint. An empty list allows all source components.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#AllowSrcCompIn = 
+
 # Group parallel/ redundant data links to use the same list of connected
 # systems. This is needed to prevent messages from one of the parallel links
 # being send back on the other one right away.

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -484,14 +484,14 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
     }
 
     // If filter is defined and message is not in the set: discard it
-    if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_msg_ids.empty()
-        && !vector_contains(_allowed_msg_ids, pbuf->curr.msg_id)) {
+    if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_outgoing_msg_ids.empty()
+        && !vector_contains(_allowed_outgoing_msg_ids, pbuf->curr.msg_id)) {
         return Endpoint::AcceptState::Filtered;
     }
 
     // If filter is defined and message is not in the set: discard it
-    if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_src_comps.empty()
-        && !vector_contains(_allowed_src_comps, pbuf->curr.src_compid)) {
+    if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_outgoing_src_comps.empty()
+        && !vector_contains(_allowed_outgoing_src_comps, pbuf->curr.src_compid)) {
         return Endpoint::AcceptState::Filtered;
     }
 
@@ -654,11 +654,11 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     }
 
     for (auto msg_id : conf.allow_msg_id_out) {
-        this->filter_add_allowed_msg_id(msg_id);
+        this->filter_add_allowed_out_msg_id(msg_id);
     }
 
     for (auto src_comp : conf.allow_src_comp_out) {
-        this->filter_add_allowed_src_comp(src_comp);
+        this->filter_add_allowed_out_src_comp(src_comp);
     }
 
     this->_group_name = conf.group;
@@ -958,11 +958,11 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     }
 
     for (auto msg_id : conf.allow_msg_id_out) {
-        this->filter_add_allowed_msg_id(msg_id);
+        this->filter_add_allowed_out_msg_id(msg_id);
     }
 
     for (auto src_comp : conf.allow_src_comp_out) {
-        this->filter_add_allowed_src_comp(src_comp);
+        this->filter_add_allowed_out_src_comp(src_comp);
     }
 
     this->_group_name = conf.group;
@@ -1300,11 +1300,11 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     this->_retry_timeout = conf.retry_timeout;
 
     for (auto msg_id : conf.allow_msg_id_out) {
-        this->filter_add_allowed_msg_id(msg_id);
+        this->filter_add_allowed_out_msg_id(msg_id);
     }
 
     for (auto src_comp : conf.allow_src_comp_out) {
-        this->filter_add_allowed_src_comp(src_comp);
+        this->filter_add_allowed_out_src_comp(src_comp);
     }
 
     this->_group_name = conf.group;

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -62,6 +62,8 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"FlowControl",     false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
     {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_out)},
+    {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_in)},
+    {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_in)},
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
@@ -74,6 +76,8 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
+    {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_in)},
+    {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -85,6 +89,8 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
+    {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_in)},
+    {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -198,13 +204,23 @@ int Endpoint::handle_read()
             break;
         }
 
-        if (allowed_by_dedup(&buf)) {
-            _add_sys_comp_id(buf.curr.src_sysid, buf.curr.src_compid);
-            Mainloop::get_instance().route_msg(&buf);
-        } else {
+        // check incoming message filters
+        if (!allowed_by_dedup(&buf)) {
             if (Log::get_max_level() >= Log::Level::DEBUG) {
                 log_debug("Message %u discarded by de-duplication", buf.curr.msg_id);
             }
+        } else if (!allowed_by_incoming_filters(&buf)) {
+            if (Log::get_max_level() >= Log::Level::DEBUG) {
+                log_debug("Message %u to %d/%d from %u/%u discarded by incoming filters",
+                          buf.curr.msg_id,
+                          buf.curr.target_sysid,
+                          buf.curr.target_compid,
+                          buf.curr.src_sysid,
+                          buf.curr.src_compid);
+            }
+        } else {
+            _add_sys_comp_id(buf.curr.src_sysid, buf.curr.src_compid);
+            Mainloop::get_instance().route_msg(&buf);
         }
     }
 
@@ -526,6 +542,24 @@ bool Endpoint::allowed_by_dedup(const buffer *buf) const
     return Mainloop::get_instance().dedup_check_msg(buf);
 }
 
+bool Endpoint::allowed_by_incoming_filters(const buffer *buf) const
+{
+    // If filter is defined and message is not in the set: discard it
+    if (buf->curr.msg_id != UINT32_MAX && !_allowed_incoming_msg_ids.empty()
+        && !vector_contains(_allowed_incoming_msg_ids, buf->curr.msg_id)) {
+        return false;
+    }
+
+    // If filter is defined and message is not in the set: discard it
+    if (!_allowed_incoming_src_comps.empty()
+        && !vector_contains(_allowed_incoming_src_comps, buf->curr.src_compid)) {
+        return false;
+    }
+
+    // everything else seems to be allowed
+    return true;
+}
+
 void Endpoint::link_group_member(std::shared_ptr<Endpoint> other)
 {
     if (_group_name.empty() || other->get_group_name() != _group_name) {
@@ -659,6 +693,14 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
 
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+
+    for (auto msg_id : conf.allow_msg_id_in) {
+        this->filter_add_allowed_in_msg_id(msg_id);
+    }
+
+    for (auto src_comp : conf.allow_src_comp_in) {
+        this->filter_add_allowed_in_src_comp(src_comp);
     }
 
     this->_group_name = conf.group;
@@ -963,6 +1005,14 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
 
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+
+    for (auto msg_id : conf.allow_msg_id_in) {
+        this->filter_add_allowed_in_msg_id(msg_id);
+    }
+
+    for (auto src_comp : conf.allow_src_comp_in) {
+        this->filter_add_allowed_in_src_comp(src_comp);
     }
 
     this->_group_name = conf.group;
@@ -1305,6 +1355,14 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+
+    for (auto msg_id : conf.allow_msg_id_in) {
+        this->filter_add_allowed_in_msg_id(msg_id);
+    }
+
+    for (auto src_comp : conf.allow_src_comp_in) {
+        this->filter_add_allowed_in_src_comp(src_comp);
     }
 
     this->_group_name = conf.group;

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -62,8 +62,10 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"FlowControl",     false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
     {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_out)},
+    {"AllowSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_out)},
     {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_in)},
     {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_in)},
+    {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
@@ -76,8 +78,10 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
+    {"AllowSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_out)},
     {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_in)},
     {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
+    {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -89,8 +93,10 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
+    {"AllowSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_out)},
     {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_in)},
     {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
+    {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -511,6 +517,12 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         return Endpoint::AcceptState::Filtered;
     }
 
+    // If filter is defined and message is not in the set: discard it
+    if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_outgoing_src_systems.empty()
+        && !vector_contains(_allowed_outgoing_src_systems, pbuf->curr.src_sysid)) {
+        return Endpoint::AcceptState::Filtered;
+    }
+
     // Message is broadcast on sysid or sysid is non-existent: accept msg
     if (pbuf->curr.target_sysid == 0 || pbuf->curr.target_sysid == -1) {
         return Endpoint::AcceptState::Accepted;
@@ -553,6 +565,12 @@ bool Endpoint::allowed_by_incoming_filters(const buffer *buf) const
     // If filter is defined and message is not in the set: discard it
     if (!_allowed_incoming_src_comps.empty()
         && !vector_contains(_allowed_incoming_src_comps, buf->curr.src_compid)) {
+        return false;
+    }
+
+    // If filter is defined and message is not in the set: discard it
+    if (!_allowed_incoming_src_systems.empty()
+        && !vector_contains(_allowed_incoming_src_systems, buf->curr.src_sysid)) {
         return false;
     }
 
@@ -690,17 +708,21 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
     }
-
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+    for (auto src_sys : conf.allow_src_sys_out) {
+        this->filter_add_allowed_out_src_sys(src_sys);
     }
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
     }
-
     for (auto src_comp : conf.allow_src_comp_in) {
         this->filter_add_allowed_in_src_comp(src_comp);
+    }
+    for (auto src_sys : conf.allow_src_sys_out) {
+        this->filter_add_allowed_in_src_sys(src_sys);
     }
 
     this->_group_name = conf.group;
@@ -1002,17 +1024,21 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
     }
-
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+    for (auto src_sys : conf.allow_src_sys_out) {
+        this->filter_add_allowed_out_src_sys(src_sys);
     }
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
     }
-
     for (auto src_comp : conf.allow_src_comp_in) {
         this->filter_add_allowed_in_src_comp(src_comp);
+    }
+    for (auto src_sys : conf.allow_src_sys_out) {
+        this->filter_add_allowed_in_src_sys(src_sys);
     }
 
     this->_group_name = conf.group;
@@ -1352,17 +1378,21 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
     }
-
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+    for (auto src_sys : conf.allow_src_sys_out) {
+        this->filter_add_allowed_out_src_sys(src_sys);
     }
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
     }
-
     for (auto src_comp : conf.allow_src_comp_in) {
         this->filter_add_allowed_in_src_comp(src_comp);
+    }
+    for (auto src_sys : conf.allow_src_sys_out) {
+        this->filter_add_allowed_in_src_sys(src_sys);
     }
 
     this->_group_name = conf.group;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -43,8 +43,10 @@ struct UartEndpointConfig {
     bool flowcontrol{false};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint8_t> allow_src_sys_out;
     std::vector<uint32_t> allow_msg_id_in;
     std::vector<uint8_t> allow_src_comp_in;
+    std::vector<uint8_t> allow_src_sys_in;
     std::string group;
 };
 
@@ -57,8 +59,10 @@ struct UdpEndpointConfig {
     Mode mode;
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint8_t> allow_src_sys_out;
     std::vector<uint32_t> allow_msg_id_in;
     std::vector<uint8_t> allow_src_comp_in;
+    std::vector<uint8_t> allow_src_sys_in;
     std::string group;
 };
 
@@ -69,8 +73,10 @@ struct TcpEndpointConfig {
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint8_t> allow_src_sys_out;
     std::vector<uint32_t> allow_msg_id_in;
     std::vector<uint8_t> allow_src_comp_in;
+    std::vector<uint8_t> allow_src_sys_in;
     std::string group;
 };
 
@@ -163,6 +169,10 @@ public:
     {
         _allowed_outgoing_src_comps.push_back(src_comp);
     }
+    void filter_add_allowed_out_src_sys(uint8_t src_sys)
+    {
+        _allowed_outgoing_src_systems.push_back(src_sys);
+    }
     void filter_add_allowed_in_msg_id(uint32_t msg_id)
     {
         _allowed_incoming_msg_ids.push_back(msg_id);
@@ -170,6 +180,10 @@ public:
     void filter_add_allowed_in_src_comp(uint8_t src_comp)
     {
         _allowed_incoming_src_comps.push_back(src_comp);
+    }
+    void filter_add_allowed_in_src_sys(uint8_t src_sys)
+    {
+        _allowed_incoming_src_systems.push_back(src_sys);
     }
 
     bool allowed_by_dedup(const buffer *pbuf) const;
@@ -223,8 +237,10 @@ protected:
 private:
     std::vector<uint32_t> _allowed_outgoing_msg_ids;
     std::vector<uint8_t> _allowed_outgoing_src_comps;
+    std::vector<uint8_t> _allowed_outgoing_src_systems;
     std::vector<uint32_t> _allowed_incoming_msg_ids;
     std::vector<uint8_t> _allowed_incoming_src_comps;
+    std::vector<uint8_t> _allowed_incoming_src_systems;
 };
 
 class UartEndpoint : public Endpoint {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -149,8 +149,14 @@ public:
 
     AcceptState accept_msg(const struct buffer *pbuf) const;
 
-    void filter_add_allowed_msg_id(uint32_t msg_id) { _allowed_msg_ids.push_back(msg_id); }
-    void filter_add_allowed_src_comp(uint8_t src_comp) { _allowed_src_comps.push_back(src_comp); }
+    void filter_add_allowed_out_msg_id(uint32_t msg_id)
+    {
+        _allowed_outgoing_msg_ids.push_back(msg_id);
+    }
+    void filter_add_allowed_out_src_comp(uint8_t src_comp)
+    {
+        _allowed_outgoing_src_comps.push_back(src_comp);
+    }
 
     bool allowed_by_dedup(const buffer *pbuf) const;
 
@@ -200,8 +206,8 @@ protected:
     std::vector<uint16_t> _sys_comp_ids;
 
 private:
-    std::vector<uint32_t> _allowed_msg_ids;
-    std::vector<uint8_t> _allowed_src_comps;
+    std::vector<uint32_t> _allowed_outgoing_msg_ids;
+    std::vector<uint8_t> _allowed_outgoing_src_comps;
 };
 
 class UartEndpoint : public Endpoint {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -43,6 +43,8 @@ struct UartEndpointConfig {
     bool flowcontrol{false};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint32_t> allow_msg_id_in;
+    std::vector<uint8_t> allow_src_comp_in;
     std::string group;
 };
 
@@ -55,6 +57,8 @@ struct UdpEndpointConfig {
     Mode mode;
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint32_t> allow_msg_id_in;
+    std::vector<uint8_t> allow_src_comp_in;
     std::string group;
 };
 
@@ -65,6 +69,8 @@ struct TcpEndpointConfig {
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint32_t> allow_msg_id_in;
+    std::vector<uint8_t> allow_src_comp_in;
     std::string group;
 };
 
@@ -157,8 +163,17 @@ public:
     {
         _allowed_outgoing_src_comps.push_back(src_comp);
     }
+    void filter_add_allowed_in_msg_id(uint32_t msg_id)
+    {
+        _allowed_incoming_msg_ids.push_back(msg_id);
+    }
+    void filter_add_allowed_in_src_comp(uint8_t src_comp)
+    {
+        _allowed_incoming_src_comps.push_back(src_comp);
+    }
 
     bool allowed_by_dedup(const buffer *pbuf) const;
+    bool allowed_by_incoming_filters(const struct buffer *pbuf) const;
 
     void link_group_member(std::shared_ptr<Endpoint> other);
 
@@ -208,6 +223,8 @@ protected:
 private:
     std::vector<uint32_t> _allowed_outgoing_msg_ids;
     std::vector<uint8_t> _allowed_outgoing_src_comps;
+    std::vector<uint32_t> _allowed_incoming_msg_ids;
+    std::vector<uint8_t> _allowed_incoming_src_comps;
 };
 
 class UartEndpoint : public Endpoint {

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -256,6 +256,58 @@ TEST(EndpointTest, AcceptMsg_OutCompFilter)
     EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Filtered);
 }
 
+TEST(EndpointTest, AcceptMsg_InMsgIdFilter)
+{
+    TestEndpoint endpoint;
+    buffer test_msg;
+
+    // broadcast message should normally be accepted
+    test_msg.curr.src_sysid = 1;
+    test_msg.curr.src_compid = 1;
+    test_msg.curr.target_sysid = -1;
+    test_msg.curr.target_compid = -1;
+
+    // only allow heartbeat messages
+    endpoint.filter_add_allowed_in_msg_id(1);
+
+    // accept message with allowed message ID
+    test_msg.curr.msg_id = 1;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), true);
+
+    // reject message with other message IDs
+    test_msg.curr.msg_id = 2;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), false);
+    test_msg.curr.msg_id = 255;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), false);
+    test_msg.curr.msg_id = 368;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), false);
+}
+
+TEST(EndpointTest, AcceptMsg_InCompFilter)
+{
+    TestEndpoint endpoint;
+    buffer test_msg;
+
+    // broadcast message should normally be accepted
+    test_msg.curr.msg_id = 1;
+    test_msg.curr.src_sysid = 1;
+    test_msg.curr.target_sysid = -1;
+    test_msg.curr.target_compid = -1;
+
+    // only allow heartbeat messages
+    endpoint.filter_add_allowed_in_src_comp(1);
+
+    // accept message with allowed source component ID
+    test_msg.curr.src_compid = 1;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), true);
+
+    // reject message with other source component IDs
+    test_msg.curr.src_compid = 2;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), false);
+    test_msg.curr.src_compid = 255;
+    EXPECT_EQ(endpoint.allowed_by_incoming_filters(&test_msg), false);
+}
+
 /**
  * UART Endpoint
  */

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -231,6 +231,31 @@ TEST(EndpointTest, AcceptMsg_OutMsgIdFilter)
     EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Filtered);
 }
 
+TEST(EndpointTest, AcceptMsg_OutCompFilter)
+{
+    TestEndpoint endpoint;
+    buffer test_msg;
+
+    // broadcast message should normally be accepted
+    test_msg.curr.msg_id = 1;
+    test_msg.curr.src_sysid = 1;
+    test_msg.curr.target_sysid = -1;
+    test_msg.curr.target_compid = -1;
+
+    // only allow heartbeat messages
+    endpoint.filter_add_allowed_out_src_comp(1);
+
+    // accept message with allowed source component ID
+    test_msg.curr.src_compid = 1;
+    EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Accepted);
+
+    // reject message with other source component IDs
+    test_msg.curr.src_compid = 2;
+    EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Filtered);
+    test_msg.curr.src_compid = 255;
+    EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Filtered);
+}
+
 /**
  * UART Endpoint
  */

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -117,7 +117,7 @@ TEST(EndpointTest, HasSysCompId)
     EXPECT_FALSE(endpoint.has_sys_comp_id(255, 1));
 }
 
-TEST(EndpointTest, AcceptMsgEmptyKnownSystems)
+TEST(EndpointTest, AcceptMsg_EmptyKnownSystems)
 {
     TestEndpoint endpoint;
     buffer test_msg;
@@ -151,7 +151,7 @@ TEST(EndpointTest, AcceptMsgEmptyKnownSystems)
     EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Rejected);
 }
 
-TEST(EndpointTest, AcceptMsgWithKnownSystems)
+TEST(EndpointTest, AcceptMsg_WithKnownSystems)
 {
     TestEndpoint endpoint;
     buffer test_msg;
@@ -204,7 +204,7 @@ TEST(EndpointTest, AcceptMsgWithKnownSystems)
     EXPECT_EQ(endpoint.accept_msg(&test_msg), Endpoint::AcceptState::Rejected);
 }
 
-TEST(EndpointTest, AcceptMsgMsgIdFilter)
+TEST(EndpointTest, AcceptMsg_OutMsgIdFilter)
 {
     TestEndpoint endpoint;
     buffer test_msg;
@@ -216,7 +216,7 @@ TEST(EndpointTest, AcceptMsgMsgIdFilter)
     test_msg.curr.target_compid = -1;
 
     // only allow heartbeat messages
-    endpoint.filter_add_allowed_msg_id(1);
+    endpoint.filter_add_allowed_out_msg_id(1);
 
     // accept message with allowed message ID
     test_msg.curr.msg_id = 1;


### PR DESCRIPTION
We already have message filters on the outgoing side of an endpoint. This PR adds the same set of filters to the receiving side e.g. to limit the interaction abilities of some ground station software as requested in #345.