### PR TITLE
added fflush to ensure propper behaviour of anonymous piping 

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -633,6 +633,7 @@ void Endpoint::print_statistics()
     printf("\n\t\tTotal: %u %" PRIu64 "KB", _stat.write.total, _stat.write.bytes / 1000);
     printf("\n\t}");
     printf("\n}\n");
+    fflush(stdout);
 }
 
 uint8_t Endpoint::get_trimmed_zeros(const mavlink_msg_entry_t *msg_entry,


### PR DESCRIPTION
Without fflush the stdout messages are flushed into anonymous pipes in 4KB chunks (in Linux: once the standard buffersize for anonymous pipes is filled). This introduces difficulties for parsing the output through piping. fflush(stdout) at the end of the printf statements solves this issue.