### PR TITLE
Ignore comp id fix

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -67,7 +67,7 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_in)},
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
-    {"IgnoreCompId",    false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, ignore_comp_id)},
+    {"IgnoreCompId",    false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, ignorecompid)},
     {}
 };
 
@@ -84,7 +84,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
-    {"IgnoreCompId",    false,  ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, ignore_comp_id)},
+    {"IgnoreCompId",    false,  ConfFile::parse_bool,           OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, ignorecompid)},
     {}
 };
 
@@ -100,7 +100,7 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
-    {"IgnoreCompId",    false,  ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, ignore_comp_id)},
+    {"IgnoreCompId",    false,  ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, ignorecompid)},
     {}
 };
 // clang-format on
@@ -545,7 +545,7 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         return Endpoint::AcceptState::Accepted;
     }
 
-    if( ignore_comp_id && has_sys_id(pbuf->curr.target_sysid)) {
+    if(ignore_comp_id && has_sys_id(pbuf->curr.target_sysid)) {
         return Endpoint::AcceptState::Accepted;
     }
     // This endpoint has the sniffer_sysid: accept
@@ -714,8 +714,8 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
         }
     }
 
-    if (conf.ignore_comp_id) {
-        this->ignore_comp_id = conf.ignore_comp_id;
+    if (conf.ignorecompid) {
+        this->ignore_comp_id = conf.ignorecompid;
     }
 
     for (auto msg_id : conf.allow_msg_id_out) {
@@ -1034,8 +1034,8 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
         return false;
     }
 
-    if (conf.ignore_comp_id) {
-        this->ignore_comp_id = conf.ignore_comp_id;
+    if (conf.ignorecompid) {
+        this->ignore_comp_id = conf.ignorecompid;
     }
 
     for (auto msg_id : conf.allow_msg_id_out) {
@@ -1392,8 +1392,8 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     this->_port = conf.port;
     this->_retry_timeout = conf.retry_timeout;
 
-    if (conf.ignore_comp_id) {
-        this->ignore_comp_id = conf.ignore_comp_id;
+    if (conf.ignorecompid) {
+        this->ignore_comp_id = conf.ignorecompid;
     }
 
     for (auto msg_id : conf.allow_msg_id_out) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -48,7 +48,7 @@ struct UartEndpointConfig {
     std::vector<uint8_t> allow_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::string group;
-    bool ignore_comp_id;
+    bool ignorecompid{false};
 };
 
 struct UdpEndpointConfig {
@@ -65,7 +65,7 @@ struct UdpEndpointConfig {
     std::vector<uint8_t> allow_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::string group;
-    bool ignore_comp_id;
+    bool ignorecompid{false};
 };
 
 struct TcpEndpointConfig {
@@ -80,7 +80,7 @@ struct TcpEndpointConfig {
     std::vector<uint8_t> allow_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::string group;
-    bool ignore_comp_id;
+    bool ignorecompid{false};
 };
 
 /*
@@ -199,7 +199,7 @@ public:
 
     struct buffer rx_buf;
     struct buffer tx_buf;
-
+    bool ignore_comp_id = false;
     // An endpoint with this system id becomes a "sniffer" and all
     // messages are accepted.
     static uint16_t sniffer_sysid;
@@ -216,7 +216,7 @@ protected:
 
     std::string _group_name{}; // empty name to disable endpoint groups
     std::vector<std::shared_ptr<Endpoint>> _group_members{};
-    bool ignore_comp_id = false;
+    
     // Statistics
     struct {
         struct {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -48,6 +48,7 @@ struct UartEndpointConfig {
     std::vector<uint8_t> allow_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::string group;
+    bool ignore_comp_id;
 };
 
 struct UdpEndpointConfig {
@@ -64,6 +65,7 @@ struct UdpEndpointConfig {
     std::vector<uint8_t> allow_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::string group;
+    bool ignore_comp_id;
 };
 
 struct TcpEndpointConfig {
@@ -78,6 +80,7 @@ struct TcpEndpointConfig {
     std::vector<uint8_t> allow_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::string group;
+    bool ignore_comp_id;
 };
 
 /*
@@ -213,7 +216,7 @@ protected:
 
     std::string _group_name{}; // empty name to disable endpoint groups
     std::vector<std::shared_ptr<Endpoint>> _group_members{};
-
+    bool ignore_comp_id = false;
     // Statistics
     struct {
         struct {

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -186,7 +186,13 @@ void Mainloop::route_msg(struct buffer *buf)
             unknown = false;
             break;
         case Endpoint::AcceptState::Rejected:
-            // fall through
+            log_debug("Endpoint [%d] rejected message %u to %d/%d from %u/%u",
+                      e->fd,
+                      buf->curr.msg_id,
+                      buf->curr.target_sysid,
+                      buf->curr.target_compid,
+                      buf->curr.src_sysid,
+                      buf->curr.src_compid);
         default:
             break; // do nothing (will count as unknown)
         }
@@ -380,7 +386,7 @@ bool Mainloop::add_endpoints(const Configuration &config)
 
     for (const auto &conf : config.udp_configs) {
         auto udp = std::make_shared<UdpEndpoint>(conf.name);
-
+        
         if (!udp->setup(conf)) {
             return false;
         }


### PR DESCRIPTION
This PR adds option to route ignore component ids for a system. 