### PR TITLE
Replace deprecated get_pkgconfig_variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ dep_thread = dependency('threads')
 systemd_system_unit_dir = get_option('systemdsystemunitdir')
 if systemd_system_unit_dir == 'auto'
 		dep_systemd = dependency('systemd')
-		systemd_system_unit_dir = dep_systemd.get_pkgconfig_variable('systemdsystemunitdir')
+		systemd_system_unit_dir = dep_systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 endif
 
 dep_gtest = dependency('gtest', main : true, required : false)


### PR DESCRIPTION
[get_pkgconfig_variable](https://mesonbuild.com/Reference-manual_returned_dep.html#depget_pkgconfig_variable) => [get_variable](https://mesonbuild.com/Reference-manual_returned_dep.html#depget_variable)