### PR TITLE
Filters: Add blocker filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ Message filters:
   - BlockSrcSysIn: If set, block messages from the listed MAVLink source
     systems to be received on this endpoint
 
+    Note that while using "Allow" and "Block" filters on the same identifier 
+    within an endpoint doesn't make sense, using them on different identifiers 
+    can be useful (for example, allowing only specific outgoing SysID, and
+    blocking this system from sending some unwanted message IDs).
+
 Message de-duplication:
 
   - If enabled, each incoming message is checked, whether another copy was

--- a/README.md
+++ b/README.md
@@ -231,31 +231,26 @@ Message filters:
 
   - AllowMsgIdOut: If set, only allow messages with the listed message IDs to
     be sent via this endpoint
-  - BlockMsgIdOut: If set, block messages with the listed message IDs to
-    be sent via this endpoint
-
+  - BlockMsgIdOut: If set, block messages with the listed message IDs to be sent
+    via this endpoint
   - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
     component IDs to be sent via this endpoint
   - BlockSrcCompOut: If set, block messages from the listed MAVLink source
     component IDs to be sent via this endpoint
-  
   - AllowSrcSysOut: If set, only allow messages from the listed MAVLink source
     systems to be sent via this endpoint
   - BlockSrcSysOut: If set, block messages from the listed MAVLink source
     systems to be sent via this endpoint
-  
   - AllowMsgIdIn: If set, only allow messages with the listed message IDs to
     be received on this endpoint. Since message ID 0 is not used, only allowing
     this message ID can be used to block all incoming traffic on this endpoint,
     e.g. to block interaction with the drone while still receiving telemetry.
   - BlockMsgIdIn: If set, block messages with the listed message IDs to
-    be received on this endpoint. 
-  
+    be received on this endpoint
   - AllowSrcCompIn: If set, only allow messages from the listed MAVLink source
     component IDs to be received on this endpoint
   - BlockSrcCompIn: If set, block messages from the listed MAVLink source
     component IDs to be received on this endpoint
-  
   - AllowSrcSysIn: If set, only allow messages from the listed MAVLink source
     systems to be received on this endpoint
   - BlockSrcSysIn: If set, block messages from the listed MAVLink source

--- a/README.md
+++ b/README.md
@@ -231,17 +231,34 @@ Message filters:
 
   - AllowMsgIdOut: If set, only allow messages with the listed message IDs to
     be sent via this endpoint
+  - BlockMsgIdOut: If set, block messages with the listed message IDs to
+    be sent via this endpoint
+
   - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
     component IDs to be sent via this endpoint
+  - BlockSrcCompOut: If set, block messages from the listed MAVLink source
+    component IDs to be sent via this endpoint
+  
   - AllowSrcSysOut: If set, only allow messages from the listed MAVLink source
     systems to be sent via this endpoint
+  - BlockSrcSysOut: If set, block messages from the listed MAVLink source
+    systems to be sent via this endpoint
+  
   - AllowMsgIdIn: If set, only allow messages with the listed message IDs to
     be received on this endpoint. Since message ID 0 is not used, only allowing
     this message ID can be used to block all incoming traffic on this endpoint,
     e.g. to block interaction with the drone while still receiving telemetry.
+  - BlockMsgIdIn: If set, block messages with the listed message IDs to
+    be received on this endpoint. 
+  
   - AllowSrcCompIn: If set, only allow messages from the listed MAVLink source
     component IDs to be received on this endpoint
+  - BlockSrcCompIn: If set, block messages from the listed MAVLink source
+    component IDs to be received on this endpoint
+  
   - AllowSrcSysIn: If set, only allow messages from the listed MAVLink source
+    systems to be received on this endpoint
+  - BlockSrcSysIn: If set, block messages from the listed MAVLink source
     systems to be received on this endpoint
 
 Message de-duplication:

--- a/README.md
+++ b/README.md
@@ -229,37 +229,21 @@ Routing rules:
 
 Message filters:
 
-  - AllowMsgIdOut: If set, only allow messages with the listed message IDs to
-    be sent via this endpoint
-  - BlockMsgIdOut: If set, block messages with the listed message IDs to be sent
-    via this endpoint
-  - AllowSrcCompOut: If set, only allow messages from the listed MAVLink source
-    component IDs to be sent via this endpoint
-  - BlockSrcCompOut: If set, block messages from the listed MAVLink source
-    component IDs to be sent via this endpoint
-  - AllowSrcSysOut: If set, only allow messages from the listed MAVLink source
-    systems to be sent via this endpoint
-  - BlockSrcSysOut: If set, block messages from the listed MAVLink source
-    systems to be sent via this endpoint
-  - AllowMsgIdIn: If set, only allow messages with the listed message IDs to
-    be received on this endpoint. Since message ID 0 is not used, only allowing
-    this message ID can be used to block all incoming traffic on this endpoint,
-    e.g. to block interaction with the drone while still receiving telemetry.
-  - BlockMsgIdIn: If set, block messages with the listed message IDs to
-    be received on this endpoint
-  - AllowSrcCompIn: If set, only allow messages from the listed MAVLink source
-    component IDs to be received on this endpoint
-  - BlockSrcCompIn: If set, block messages from the listed MAVLink source
-    component IDs to be received on this endpoint
-  - AllowSrcSysIn: If set, only allow messages from the listed MAVLink source
-    systems to be received on this endpoint
-  - BlockSrcSysIn: If set, block messages from the listed MAVLink source
-    systems to be received on this endpoint
-
-    Note that while using "Allow" and "Block" filters on the same identifier 
+  - There are two points where messages can be filtered on each endpoint:
+    - **In**: Messages which are received (from the outside) on this endpoint are dropped or allowed based on the respecitive filter rules before they'll be routed to other endpoints
+    - **Out**: Messages are dropped or allowed based on the endpoint's filter rules before being transmitted. So this is after internal routing (see "routing rules" chapter above).
+  - A message filter can be based on one of these message identifiers:
+    - **MsgId**: Filter message based on it's MAVLink message ID (message type like HEARTBEAT)
+    - **SrcSys**: Filter message based on it's MAVLink source system ID
+    - **SrcComp**: Filter message based on it's MAVLink source component ID
+  - And a message filter can either be a block- or allow-list:
+    - **Block**: Discard all messages matching the respective identifier (and allow all other ones)
+    - **Allow**: Allow all messages matching the respective identifier (and discard all other ones)
+    - Note that while using "Allow" and "Block" filters on the same identifier 
     within an endpoint doesn't make sense, using them on different identifiers 
     can be useful (for example, allowing only specific outgoing SysID, and
     blocking this system from sending some unwanted message IDs).
+  - So a filter might be named `AllowMsgIdOut` to only allow messages with the listed message ID to be transmitted on that endpoint. See the example config [examples/config.sample](examples/config.sample) for the exact name of each filter parameter.
 
 Message de-duplication:
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -116,11 +116,24 @@
 # Default: Empty list (disabled)
 #AllowMsgIdOut = 
 
+# Block specified MAVLink message IDs to be sent via this endpoint. An
+# empty list won't block any message IDs.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#BlockMsgIdOut = 
+
+
 # Only allow messages from the specified MAVLink source component IDs to be
 # sent via this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
 #AllowSrcCompOut = 
+
+# Block messages from the specified MAVLink source component IDs to be
+# sent via this endpoint. An empty list won't block any source components.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#BlockSrcCompOut = 
 
 # Only allow messages from the specified MAVLink source systems to be sent via
 # this endpoint. An empty list allows all source components.
@@ -128,11 +141,23 @@
 # Default: Empty list (disabled)
 #AllowSrcSysOut = 
 
+# Block messages from the specified MAVLink source systems to be sent via
+# this endpoint. An empty list won't block any source systems.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#BlockSrcSysOut = 
+
 # Only allow specified MAVLink message IDs to be received on this endpoint.
 # An empty list allows all message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
 #AllowMsgIdIn = 
+
+# Block specified MAVLink message IDs to be received on this endpoint.
+# An empty list won't block any message IDs.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#BlockMsgIdIn = 
 
 # Only allow messages from the specified MAVLink source component IDs to be
 # received on this endpoint. An empty list allows all source components.
@@ -140,11 +165,23 @@
 # Default: Empty list (disabled)
 #AllowSrcCompIn = 
 
+# Block messages from the specified MAVLink source component IDs to be
+# received on this endpoint. An empty list won't block any source components.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#BlockSrcCompIn = 
+
 # Only allow messages from the specified MAVLink source systems to be received
 # on this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcSysIn = 
+#AllowSrcSysIn =
+
+# Block messages from the specified MAVLink source systems to be received
+# on this endpoint. An empty list won't block any source systems.
+# Format: Comma separated list of integers
+# Default: Empty list (disabled)
+#BlockSrcSysIn =
 
 # Group parallel/ redundant data links to use the same list of connected
 # systems. This is needed to prevent messages from one of the parallel links

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -122,7 +122,6 @@
 # Default: Empty list (disabled)
 #BlockMsgIdOut = 
 
-
 # Only allow messages from the specified MAVLink source component IDs to be
 # sent via this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
@@ -175,13 +174,13 @@
 # on this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcSysIn =
+#AllowSrcSysIn = 
 
 # Block messages from the specified MAVLink source systems to be received
 # on this endpoint. An empty list won't block any source systems.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcSysIn =
+#BlockSrcSysIn = 
 
 # Group parallel/ redundant data links to use the same list of connected
 # systems. This is needed to prevent messages from one of the parallel links

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -82,18 +82,18 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
-    {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
-    {"BlockMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
-    {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
-    {"BlockSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_out)},
-    {"AllowSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_out)},
-    {"BlockSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_out)},
-    {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_in)},
-    {"BlockMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_in)},
-    {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
-    {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_in)},
-    {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
-    {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
+    {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
+    {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
+    {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
+    {"BlockSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_out)},
+    {"AllowSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_out)},
+    {"BlockSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_out)},
+    {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_in)},
+    {"BlockMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_in)},
+    {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
+    {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_in)},
+    {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
+    {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -103,18 +103,18 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
-    {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
-    {"BlockMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},
-    {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
-    {"BlockSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_out)},
-    {"AllowSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_out)},
-    {"BlockSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_out)},
-    {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_in)},
-    {"BlockMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_in)},
-    {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
-    {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_in)},
-    {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
-    {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
+    {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
+    {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},
+    {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
+    {"BlockSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_out)},
+    {"AllowSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_out)},
+    {"BlockSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_out)},
+    {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_in)},
+    {"BlockMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_in)},
+    {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
+    {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_in)},
+    {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
+    {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -778,7 +778,6 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     for (auto src_sys : conf.block_src_sys_out) {
         this->filter_add_blocked_out_src_sys(src_sys);
     }
-
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
@@ -1504,6 +1503,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
     }
+
     this->_group_name = conf.group;
 
     if (!this->open(conf.address, conf.port)) {

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -61,11 +61,17 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"device",          true,  ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, device)},
     {"FlowControl",     false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
     {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
+    {"BlockMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_msg_id_out)},
     {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_out)},
+    {"BlockSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_comp_out)},
     {"AllowSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_out)},
+    {"BlockSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_out)},
     {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_in)},
+    {"BlockMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_msg_id_in)},
     {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_in)},
+    {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
+    {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
@@ -76,12 +82,18 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
-    {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
-    {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
-    {"AllowSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_out)},
-    {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_in)},
-    {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
-    {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
+    {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
+    {"BlockMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
+    {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_out)},
+    {"BlockSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_out)},
+    {"AllowSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_out)},
+    {"BlockSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_out)},
+    {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_in)},
+    {"BlockMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_in)},
+    {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_comp_in)},
+    {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_in)},
+    {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
+    {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -91,12 +103,18 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
-    {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
-    {"AllowSrcCompOut", false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
-    {"AllowSrcSysOut",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_out)},
-    {"AllowMsgIdIn",    false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_in)},
-    {"AllowSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
-    {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
+    {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
+    {"BlockMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},
+    {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_out)},
+    {"BlockSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_out)},
+    {"AllowSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_out)},
+    {"BlockSrcSysOut",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_out)},
+    {"AllowMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_in)},
+    {"BlockMsgIdIn",    false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_in)},
+    {"AllowSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_comp_in)},
+    {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_in)},
+    {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
+    {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -511,15 +529,33 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         return Endpoint::AcceptState::Filtered;
     }
 
+    // If filter is defined and message is in the set: discard it
+    if (pbuf->curr.msg_id != UINT32_MAX && !_blocked_outgoing_msg_ids.empty()
+        && vector_contains(_blocked_outgoing_msg_ids, pbuf->curr.msg_id)) {
+        return Endpoint::AcceptState::Filtered;
+    }
+
     // If filter is defined and message is not in the set: discard it
     if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_outgoing_src_comps.empty()
         && !vector_contains(_allowed_outgoing_src_comps, pbuf->curr.src_compid)) {
         return Endpoint::AcceptState::Filtered;
     }
 
+    // If filter is defined and message is in the set: discard it
+    if (pbuf->curr.msg_id != UINT32_MAX && !_blocked_outgoing_src_comps.empty()
+        && vector_contains(_blocked_outgoing_src_comps, pbuf->curr.src_compid)) {
+        return Endpoint::AcceptState::Filtered;
+    }
+
     // If filter is defined and message is not in the set: discard it
     if (pbuf->curr.msg_id != UINT32_MAX && !_allowed_outgoing_src_systems.empty()
         && !vector_contains(_allowed_outgoing_src_systems, pbuf->curr.src_sysid)) {
+        return Endpoint::AcceptState::Filtered;
+    }
+
+    // If filter is defined and message is in the set: discard it
+    if (pbuf->curr.msg_id != UINT32_MAX && !_blocked_outgoing_src_systems.empty()
+        && vector_contains(_blocked_outgoing_src_systems, pbuf->curr.src_sysid)) {
         return Endpoint::AcceptState::Filtered;
     }
 
@@ -562,15 +598,33 @@ bool Endpoint::allowed_by_incoming_filters(const buffer *buf) const
         return false;
     }
 
+    // If filter is defined and message is in the set: discard it
+    if (buf->curr.msg_id != UINT32_MAX && !_blocked_incoming_msg_ids.empty()
+        && vector_contains(_blocked_incoming_msg_ids, buf->curr.msg_id)) {
+        return false;
+    }
+
     // If filter is defined and message is not in the set: discard it
     if (!_allowed_incoming_src_comps.empty()
         && !vector_contains(_allowed_incoming_src_comps, buf->curr.src_compid)) {
         return false;
     }
 
+    // If filter is defined and message is in the set: discard it
+    if (!_blocked_incoming_src_comps.empty()
+        && vector_contains(_blocked_incoming_src_comps, buf->curr.src_compid)) {
+        return false;
+    }
+
     // If filter is defined and message is not in the set: discard it
     if (!_allowed_incoming_src_systems.empty()
         && !vector_contains(_allowed_incoming_src_systems, buf->curr.src_sysid)) {
+        return false;
+    }
+
+    // If filter is defined and message is in the set: discard it
+    if (!_blocked_incoming_src_systems.empty()
+        && vector_contains(_blocked_incoming_src_systems, buf->curr.src_sysid)) {
         return false;
     }
 
@@ -709,21 +763,40 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
     }
+    for (auto msg_id : conf.block_msg_id_out) {
+        this->filter_add_blocked_out_msg_id(msg_id);
+    }
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
+    }
+    for (auto src_comp : conf.block_src_comp_out) {
+        this->filter_add_blocked_out_src_comp(src_comp);
     }
     for (auto src_sys : conf.allow_src_sys_out) {
         this->filter_add_allowed_out_src_sys(src_sys);
     }
+    for (auto src_sys : conf.block_src_sys_out) {
+        this->filter_add_blocked_out_src_sys(src_sys);
+    }
+
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
     }
+    for (auto msg_id : conf.block_msg_id_in) {
+        this->filter_add_blocked_in_msg_id(msg_id);
+    }
     for (auto src_comp : conf.allow_src_comp_in) {
         this->filter_add_allowed_in_src_comp(src_comp);
     }
+    for (auto src_comp : conf.block_src_comp_in) {
+        this->filter_add_blocked_in_src_comp(src_comp);
+    }
     for (auto src_sys : conf.allow_src_sys_in) {
         this->filter_add_allowed_in_src_sys(src_sys);
+    }
+    for (auto src_sys : conf.block_src_sys_in) {
+        this->filter_add_blocked_in_src_sys(src_sys);
     }
 
     this->_group_name = conf.group;
@@ -1025,21 +1098,39 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
     }
+    for (auto msg_id : conf.block_msg_id_out) {
+        this->filter_add_blocked_out_msg_id(msg_id);
+    }
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
     }
+    for (auto src_comp : conf.block_src_comp_out) {
+        this->filter_add_blocked_out_src_comp(src_comp);
+    }
     for (auto src_sys : conf.allow_src_sys_out) {
         this->filter_add_allowed_out_src_sys(src_sys);
+    }
+    for (auto src_sys : conf.block_src_sys_out) {
+        this->filter_add_blocked_out_src_sys(src_sys);
     }
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
     }
+    for (auto msg_id : conf.block_msg_id_in) {
+        this->filter_add_blocked_in_msg_id(msg_id);
+    }
     for (auto src_comp : conf.allow_src_comp_in) {
         this->filter_add_allowed_in_src_comp(src_comp);
     }
+    for (auto src_comp : conf.block_src_comp_in) {
+        this->filter_add_blocked_in_src_comp(src_comp);
+    }
     for (auto src_sys : conf.allow_src_sys_in) {
         this->filter_add_allowed_in_src_sys(src_sys);
+    }
+    for (auto src_sys : conf.block_src_sys_in) {
+        this->filter_add_blocked_in_src_sys(src_sys);
     }
 
     this->_group_name = conf.group;
@@ -1379,23 +1470,40 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
     }
+    for (auto msg_id : conf.block_msg_id_out) {
+        this->filter_add_blocked_out_msg_id(msg_id);
+    }
     for (auto src_comp : conf.allow_src_comp_out) {
         this->filter_add_allowed_out_src_comp(src_comp);
     }
+    for (auto src_comp : conf.block_src_comp_out) {
+        this->filter_add_blocked_out_src_comp(src_comp);
+    }
     for (auto src_sys : conf.allow_src_sys_out) {
         this->filter_add_allowed_out_src_sys(src_sys);
+    }
+    for (auto src_sys : conf.block_src_sys_out) {
+        this->filter_add_blocked_out_src_sys(src_sys);
     }
 
     for (auto msg_id : conf.allow_msg_id_in) {
         this->filter_add_allowed_in_msg_id(msg_id);
     }
+    for (auto msg_id : conf.block_msg_id_in) {
+        this->filter_add_blocked_in_msg_id(msg_id);
+    }
     for (auto src_comp : conf.allow_src_comp_in) {
         this->filter_add_allowed_in_src_comp(src_comp);
+    }
+    for (auto src_comp : conf.block_src_comp_in) {
+        this->filter_add_blocked_in_src_comp(src_comp);
     }
     for (auto src_sys : conf.allow_src_sys_in) {
         this->filter_add_allowed_in_src_sys(src_sys);
     }
-
+    for (auto src_sys : conf.block_src_sys_in) {
+        this->filter_add_blocked_in_src_sys(src_sys);
+    }
     this->_group_name = conf.group;
 
     if (!this->open(conf.address, conf.port)) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -228,7 +228,6 @@ public:
         _blocked_incoming_src_systems.push_back(src_sys);
     }
 
-
     bool allowed_by_dedup(const buffer *pbuf) const;
     bool allowed_by_incoming_filters(const struct buffer *pbuf) const;
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -42,11 +42,17 @@ struct UartEndpointConfig {
     std::vector<uint32_t> baudrates;
     bool flowcontrol{false};
     std::vector<uint32_t> allow_msg_id_out;
+    std::vector<uint32_t> block_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint8_t> block_src_comp_out;
     std::vector<uint8_t> allow_src_sys_out;
+    std::vector<uint8_t> block_src_sys_out;
     std::vector<uint32_t> allow_msg_id_in;
+    std::vector<uint32_t> block_msg_id_in;
     std::vector<uint8_t> allow_src_comp_in;
+    std::vector<uint8_t> block_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
+    std::vector<uint8_t> block_src_sys_in;
     std::string group;
 };
 
@@ -58,11 +64,17 @@ struct UdpEndpointConfig {
     unsigned long port;
     Mode mode;
     std::vector<uint32_t> allow_msg_id_out;
+    std::vector<uint32_t> block_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint8_t> block_src_comp_out;
     std::vector<uint8_t> allow_src_sys_out;
+    std::vector<uint8_t> block_src_sys_out;
     std::vector<uint32_t> allow_msg_id_in;
+    std::vector<uint32_t> block_msg_id_in;
     std::vector<uint8_t> allow_src_comp_in;
+    std::vector<uint8_t> block_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
+    std::vector<uint8_t> block_src_sys_in;
     std::string group;
 };
 
@@ -72,11 +84,17 @@ struct TcpEndpointConfig {
     unsigned long port;
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
+    std::vector<uint32_t> block_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
+    std::vector<uint8_t> block_src_comp_out;
     std::vector<uint8_t> allow_src_sys_out;
+    std::vector<uint8_t> block_src_sys_out;
     std::vector<uint32_t> allow_msg_id_in;
+    std::vector<uint32_t> block_msg_id_in;
     std::vector<uint8_t> allow_src_comp_in;
+    std::vector<uint8_t> block_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
+    std::vector<uint8_t> block_src_sys_in;
     std::string group;
 };
 
@@ -165,26 +183,51 @@ public:
     {
         _allowed_outgoing_msg_ids.push_back(msg_id);
     }
+    void filter_add_blocked_out_msg_id(uint32_t msg_id)
+    {
+        _blocked_outgoing_msg_ids.push_back(msg_id);
+    }
     void filter_add_allowed_out_src_comp(uint8_t src_comp)
     {
         _allowed_outgoing_src_comps.push_back(src_comp);
+    }
+    void filter_add_blocked_out_src_comp(uint8_t src_comp)
+    {
+        _blocked_outgoing_src_comps.push_back(src_comp);
     }
     void filter_add_allowed_out_src_sys(uint8_t src_sys)
     {
         _allowed_outgoing_src_systems.push_back(src_sys);
     }
+    void filter_add_blocked_out_src_sys(uint8_t src_sys)
+    {
+        _blocked_outgoing_src_systems.push_back(src_sys);
+    }
     void filter_add_allowed_in_msg_id(uint32_t msg_id)
     {
         _allowed_incoming_msg_ids.push_back(msg_id);
+    }
+    void filter_add_blocked_in_msg_id(uint32_t msg_id)
+    {
+        _blocked_incoming_msg_ids.push_back(msg_id);
     }
     void filter_add_allowed_in_src_comp(uint8_t src_comp)
     {
         _allowed_incoming_src_comps.push_back(src_comp);
     }
+    void filter_add_blocked_in_src_comp(uint8_t src_comp)
+    {
+        _blocked_incoming_src_comps.push_back(src_comp);
+    }
     void filter_add_allowed_in_src_sys(uint8_t src_sys)
     {
         _allowed_incoming_src_systems.push_back(src_sys);
     }
+    void filter_add_blocked_in_src_sys(uint8_t src_sys)
+    {
+        _blocked_incoming_src_systems.push_back(src_sys);
+    }
+
 
     bool allowed_by_dedup(const buffer *pbuf) const;
     bool allowed_by_incoming_filters(const struct buffer *pbuf) const;
@@ -236,11 +279,17 @@ protected:
 
 private:
     std::vector<uint32_t> _allowed_outgoing_msg_ids;
+    std::vector<uint32_t> _blocked_outgoing_msg_ids;
     std::vector<uint8_t> _allowed_outgoing_src_comps;
+    std::vector<uint8_t> _blocked_outgoing_src_comps;
     std::vector<uint8_t> _allowed_outgoing_src_systems;
+    std::vector<uint8_t> _blocked_outgoing_src_systems;
     std::vector<uint32_t> _allowed_incoming_msg_ids;
+    std::vector<uint32_t> _blocked_incoming_msg_ids;
     std::vector<uint8_t> _allowed_incoming_src_comps;
+    std::vector<uint8_t> _blocked_incoming_src_comps;
     std::vector<uint8_t> _allowed_incoming_src_systems;
+    std::vector<uint8_t> _blocked_incoming_src_systems;
 };
 
 class UartEndpoint : public Endpoint {


### PR DESCRIPTION
Like the filters that allow messages with specific parameters (msg_id, sys_id and comp_id) to pass as outgoing/incoming messages in/to endpoints, the new filters enabling blockage of messages with such parameters.
This feature co-exists with the current "allow" filters, with the only exception that a message that appears in both filter types (allow and block) will eventually be **blocked**.

Unit-tested, but not yet tested in real setup.