### PR TITLE
Don't perform UART reset on shutdown

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -727,13 +727,6 @@ UartEndpoint::UartEndpoint(std::string name)
     // nothing else to do here
 }
 
-UartEndpoint::~UartEndpoint()
-{
-    if (fd > 0) {
-        reset_uart(fd);
-    }
-}
-
 bool UartEndpoint::setup(UartEndpointConfig conf)
 {
     if (!this->validate_config(conf)) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -294,7 +294,7 @@ private:
 class UartEndpoint : public Endpoint {
 public:
     UartEndpoint(std::string name);
-    ~UartEndpoint() override;
+    ~UartEndpoint() override = default;
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }


### PR DESCRIPTION
This fixes the issue exhibited in #213. I have tested this on a Jetson TX2 and confirmed that by not performing the reset, the UART port is still accessible with minicom after shutting down mavlink router. For what its worth, setting stty's sane on the UART does not cause the same problem, so there is evidently some difference between the `reset_uart`  and stty sane despite the comment in the code. 

I hate to be the guy who offers a solution that's just "delete this code and it works", but its not clear to me what the underlying issue is and this does fix the bug.  I would totally understand if you all don't feel comfortable merging something like this, but I figured it might be helpful to throw this out there just in case. 

Would like to hear thoughts from the maintainers: Is there a compelling reason to keep this logic around?

closes #213 