### PR TITLE
Add support for tlog file splitting

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -94,6 +94,10 @@
 # Default: <false>
 # LogTelemetry = false
 
+# Max size for tlog files before they are split/rotated. Specified in bytes.
+# Valid values: <0 - 999999999999>
+# Default: 200209715200 (200MB)
+# MaxTLogFileSize = 200209715200
 
 ##
 ## UART Endpoint Configurations

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -46,6 +46,7 @@ struct LogOptions {
     unsigned long max_log_files;                  // conf "MaxLogFiles"
     int fcu_id{-1};                               // conf "LogSystemId"
     bool log_telemetry{false};                    // conf "LogTelemetry"
+    unsigned long max_tlog_file_size{209715200};  // conf "MaxTLogFileSize"
 };
 
 class LogEndpoint : public Endpoint {
@@ -72,6 +73,8 @@ protected:
     LogOptions _config;
     int _target_system_id;
     int _file = -1;
+    int _get_file(const char *extension);
+    char _filename[64];
 
     struct {
         Timeout *logging_start = nullptr;
@@ -95,7 +98,6 @@ protected:
     void _handle_auto_start_stop(const struct buffer *pbuf);
 
 private:
-    int _get_file(const char *extension);
     static uint32_t _get_prefix(DIR *dir);
     static DIR *_open_or_create_dir(const char *name);
 
@@ -104,6 +106,4 @@ private:
      * This can be configured using the .conf file, options MinFreeSpace and MaxLogFiles.
      */
     void _delete_old_logs();
-
-    char _filename[64];
 };

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -442,6 +442,7 @@ bool Mainloop::add_endpoints(const Configuration &config)
         g_endpoints.emplace_back(this->_log_endpoint);
 
         if (conf.log_telemetry) {
+            log_info("Creating TLog with MaxTLogFileSize: %lu", conf.max_tlog_file_size);
             auto tlog_endpoint = std::make_shared<TLog>(conf);
             tlog_endpoint->mark_unfinished_logs();
             g_endpoints.emplace_back(tlog_endpoint);

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -38,6 +38,7 @@ struct Configuration {
     Log::Level debug_log_level{Log::Level::INFO}; ///< conf "DebugLogLevel" or CLI "debug-log-level"
     Log::Backend log_backend{Log::Backend::STDERR}; ///< CLI "syslog"
     unsigned long dedup_period_ms;                  ///< conf "DeduplicationPeriod"
+    unsigned long max_tlog_file_size{209715200};    ///< conf "MaxTLogFileSize", default 200MB
 
     LogOptions log_config; ///< logging is in General config section, but internally an endpoint
     std::vector<UartEndpointConfig> uart_configs;

--- a/src/tlog.cpp
+++ b/src/tlog.cpp
@@ -29,6 +29,26 @@
 #include <common/log.h>
 #include <common/util.h>
 
+// needed to send messages
+#include <common/mavlink.h>
+//#include <common/mavlink_msg_param_request_list.h>
+#include <sys/socket.h>
+//#include <mavlink_helpers.h>
+
+#define SYSTEM_ID 10
+
+static int fd;
+static struct sockaddr_in sockaddr;
+
+// Define the msg_send function at the top
+static int msg_send(mavlink_message_t *msg)
+{
+    uint8_t data[MAVLINK_MAX_PACKET_LEN];
+
+    uint16_t len = mavlink_msg_to_send_buffer(data, msg);
+    return sendto(fd, data, len, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+}
+
 bool TLog::_logging_start_timeout()
 {
     //_target_system_id = -1;
@@ -78,6 +98,38 @@ void TLog::_split_logfile()
     }
 
     log_info("TLog file rotated, new file: %s", _filename);
+
+    // Send MAVLink packet to request all parameters
+    mavlink_message_t msg;
+    mavlink_msg_param_request_list_pack(
+        SYSTEM_ID, MAV_COMP_ID_ALL, &msg,
+        _target_system_id, MAV_COMP_ID_ALL);
+
+    // Send the MAVLink packet
+    msg_send(&msg);
+    log_info("Sent PARAM_REQUEST_LIST to system %d", _target_system_id);
+}
+
+void TLog::_check_and_split_logfile()
+{
+    if (_write_msg_count % 1000 != 0) {
+        return;
+    }
+
+    struct stat file_stat;
+    if (fstat(_file, &file_stat) != 0) {
+        log_error("Failed to get file stats: %m");
+        return;
+    }
+
+    if (file_stat.st_size < _max_tlog_file_size) {
+        return;
+    }
+
+    log_info("Attempting to split file, current size: %ld, max size: %ld",
+             file_stat.st_size,
+             _max_tlog_file_size);
+    _split_logfile();
 }
 
 int TLog::write_msg(const struct buffer *buffer)
@@ -91,19 +143,8 @@ int TLog::write_msg(const struct buffer *buffer)
     /* Check if we should start or stop logging */
     _handle_auto_start_stop(buffer);
 
-    /* Check if the current file size exceeds the max allowed tlog file size */
-    struct stat file_stat;
-    if (fstat(_file, &file_stat) == 0) {
-
-        if (file_stat.st_size >= _max_tlog_file_size) {
-            log_info("Attempting to split file, current size: %ld, max size: %ld",
-                     file_stat.st_size,
-                     _max_tlog_file_size);
-            _split_logfile();
-        }
-    } else {
-        log_error("Failed to get file stats: %m");
-    }
+    /* Check and split the log file if necessary */
+    _check_and_split_logfile();
 
     uint64_t ms_since_epoch = std::chrono::duration_cast<std::chrono::microseconds>(
                                   std::chrono::system_clock::now().time_since_epoch())
@@ -113,5 +154,6 @@ int TLog::write_msg(const struct buffer *buffer)
 
     write(_file, (void *)&ms_since_epoch, sizeof(uint64_t));
     write(_file, buffer->data, buffer->len);
+    _write_msg_count++;
     return buffer->len;
 }

--- a/src/tlog.h
+++ b/src/tlog.h
@@ -44,4 +44,6 @@ protected:
 
 private:
     int64_t _max_tlog_file_size;
+    size_t _write_msg_count = 0;
+    void _check_and_split_logfile();
 };

--- a/src/tlog.h
+++ b/src/tlog.h
@@ -25,6 +25,7 @@ class TLog : public LogEndpoint {
 public:
     TLog(LogOptions conf)
         : LogEndpoint{"TLog", conf}
+        , _max_tlog_file_size(conf.max_tlog_file_size)
     {
     }
 
@@ -35,8 +36,12 @@ public:
     int flush_pending_msgs() override { return -ENOSYS; }
 
 protected:
+    void _split_logfile();
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _logging_start_timeout() override;
 
     const char *_get_logfile_extension() override { return "tlog"; };
+
+private:
+    int64_t _max_tlog_file_size;
 };


### PR DESCRIPTION
Add configurable file size limit for tlog files. By default its about 200MB. Updated the example config file to reflect this, as well as the switches / CLI entries.

## Testing
Tried to running the binary with the new defaults, both blank and set config file, with and without CLI. Confirmed the files did in fact manage to split, and that the file is parsable in UAVLogViewer (https://plot.ardupilot.org/). Tested via SITL connecting to the mavlink router instance.

## Additional info

Opening this as a draft for now, as I am looking for input into the default, as well as a small annoyances (functionally works) with the file size check spamming complaints at the start before the first file is initialized.

Had to shuffle around some of the private/protected headers to get what I needed.

I am very happy to make any changes to this, as I am not very experienced with CPP, so this is more of a first proposal, and if someone wants to take further, I am happy to hand it off.

I've not performance tested this, and I am slightly worried about the frequency of which we check the size of the current log file, and maybe there is a way to do this more efficiently (haven't managed to think of any non-stupid ideas so far). Very open to suggestions of how it could be implemented, and I'll be happy to give it a go.