### PR TITLE
Add systemd-dev package to build instructions for Ubuntu 23+

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Debian/Ubuntu:
 
     $ sudo apt install git meson ninja-build pkg-config gcc g++ systemd
 
+If you are using Ubuntu 23 or newer, you may also need to install systemd-dev:
+
+    $ sudo apt install systemd-dev
+
 Fedora:
 
     $ sudo dnf install git meson gcc g++ systemd


### PR DESCRIPTION
Please double check me, but I believe the systemd-dev package needs to be installed on Ubuntu 23 or newer. See #440. 