### PR TITLE
Add an option to disable failed endpoints, without exiting

### DIFF
--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -234,7 +234,10 @@ public:
     void link_group_member(std::shared_ptr<Endpoint> other);
 
     std::string get_type() const { return this->_type; }
-    std::string get_group_name() const { return this->_group_name; };
+    std::string get_group_name() const { return this->_group_name; }
+    std::string get_name() const { return this->_name; }
+    bool is_disabled() const { return this->_disabled; }
+    void disabled(bool disabled) { this->_disabled = disabled; }
 
     struct buffer rx_buf;
     struct buffer tx_buf;
@@ -252,6 +255,7 @@ protected:
     const std::string _type; ///< UART, UDP, TCP, Log
     std::string _name;       ///< Endpoint name from config file
     size_t _last_packet_len = 0;
+    bool _disabled = false;
 
     std::string _group_name{}; // empty name to disable endpoint groups
     std::vector<std::shared_ptr<Endpoint>> _group_members{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -608,6 +608,7 @@ fail:
 
 int main(int argc, char *argv[])
 {
+    Mainloop &mainloop = Mainloop::init();
     int retcode;
     Configuration config{};
 
@@ -615,7 +616,6 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    Mainloop &mainloop = Mainloop::init(config);
     Log::open(config.log_backend);
     log_info(PACKAGE " version %s", BUILD_VERSION);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,9 +54,10 @@ static const struct option long_options[] = {{"endpoints", required_argument, nu
                                              {"verbose", no_argument, nullptr, 'v'},
                                              {"version", no_argument, nullptr, 'V'},
                                              {"sniffer-sysid", required_argument, nullptr, 's'},
+                                             {"disable-failed-endpoint", no_argument, nullptr, 'F'},
                                              {}};
 
-static const char *short_options = "he:rt:c:d:l:p:g:vV:s:T:y";
+static const char *short_options = "he:rt:c:d:l:p:g:vV:s:T:y:F";
 
 static void help(FILE *fp)
 {
@@ -84,6 +85,8 @@ static void help(FILE *fp)
         "                               logging directoy is set.\n"
         "  -g --debug-log-level <level> Set debug log level. Levels are\n"
         "                               <error|warning|info|debug>\n"
+        "  -F --disable-failed-endpoint Disable failed endpoints during init or operation\n"
+        "                               and continue to work. Default: disabled, exit on failure.\n"
         "  -v --verbose                 Verbose. Same as --debug-log-level=debug\n"
         "  -V --version                 Show version\n"
         "  -s --sniffer-sysid           Sysid that all messages are sent to.\n"
@@ -301,6 +304,10 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             config.tcp_configs.push_back(opt_tcp);
 
             free(ip);
+            break;
+        }
+        case 'F': {
+            config.skip_failed_endpoints = true;
             break;
         }
         case 'c':
@@ -601,7 +608,6 @@ fail:
 
 int main(int argc, char *argv[])
 {
-    Mainloop &mainloop = Mainloop::init();
     int retcode;
     Configuration config{};
 
@@ -609,6 +615,7 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    Mainloop &mainloop = Mainloop::init(config);
     Log::open(config.log_backend);
     log_info(PACKAGE " version %s", BUILD_VERSION);
 

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -55,12 +55,12 @@ static void setup_signal_handlers()
     sigaction(SIGPIPE, &sa, nullptr);
 }
 
-Mainloop &Mainloop::init()
+Mainloop &Mainloop::init(const Configuration &configuration)
 {
     assert(_initialized == false);
 
     _initialized = true;
-
+    _instance._configuration = configuration;
     return _instance;
 }
 
@@ -292,8 +292,16 @@ int Mainloop::loop()
                 log_error("poll error for fd %i", p->fd);
 
                 if (p->is_critical()) {
-                    log_error("Critical fd %i got error, exiting", p->fd);
-                    request_exit(EXIT_FAILURE);
+                    log_error("Critical fd %i got error", p->fd);
+                    if (_configuration.skip_failed_endpoints) {
+                        Endpoint *ep = static_cast<Endpoint *>(events[i].data.ptr);
+                        log_error("Disabling failed endpoint [%d]%s", ep->fd, ep->get_name().c_str());
+                        ep->disabled(true);
+                        this->remove_fd(ep->fd);
+                    } else {
+                        log_error("Exiting.");
+                        request_exit(EXIT_FAILURE);
+                    }
                 } else {
                     log_debug("Non-critical fd %i, error is okay.", p->fd);
                 }
@@ -371,12 +379,15 @@ bool Mainloop::add_endpoints(const Configuration &config)
         auto uart = std::make_shared<UartEndpoint>(conf.name);
 
         if (!uart->setup(conf)) {
-            return false;
+            if (!config.skip_failed_endpoints) {
+                return false;
+            }
+            log_error("Skipping endpoint %s [%s]", conf.name.c_str(), conf.device.c_str());
+        } else {
+            g_endpoints.push_back(uart);
+            auto endpoint = g_endpoints.back();
+            this->add_fd(endpoint->fd, endpoint.get(), EPOLLIN);
         }
-
-        g_endpoints.push_back(uart);
-        auto endpoint = g_endpoints.back();
-        this->add_fd(endpoint->fd, endpoint.get(), EPOLLIN);
     }
 
     for (const auto &conf : config.udp_configs) {

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -55,12 +55,11 @@ static void setup_signal_handlers()
     sigaction(SIGPIPE, &sa, nullptr);
 }
 
-Mainloop &Mainloop::init(const Configuration &configuration)
+Mainloop &Mainloop::init()
 {
     assert(_initialized == false);
 
     _initialized = true;
-    _instance._configuration = configuration;
     return _instance;
 }
 
@@ -369,6 +368,7 @@ bool Mainloop::dedup_check_msg(const buffer *buf)
 
 bool Mainloop::add_endpoints(const Configuration &config)
 {
+    _configuration = config;
     // Create UART and UDP endpoints
     if (config.sniffer_sysid != 0) {
         Endpoint::sniffer_sysid = config.sniffer_sysid;

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -44,6 +44,7 @@ struct Configuration {
     std::vector<UdpEndpointConfig> udp_configs;
     std::vector<TcpEndpointConfig> tcp_configs;
     unsigned long sniffer_sysid;
+    bool skip_failed_endpoints{false};
 };
 
 struct endpoint_entry {
@@ -92,7 +93,7 @@ public:
     /*
      * Initialize and return singleton.
      */
-    static Mainloop &init();
+    static Mainloop &init(const Configuration &configuration);
 
     /*
      * De-initialize singleton so we can start a fresh on the same
@@ -110,6 +111,7 @@ public:
 private:
     static const unsigned int LOG_AGGREGATE_INTERVAL_SEC = 5;
 
+    Configuration _configuration;
     std::vector<std::shared_ptr<Endpoint>> g_endpoints{};
     int g_tcp_fd = -1; ///< for TCP server
     std::shared_ptr<LogEndpoint> _log_endpoint{nullptr};

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -93,7 +93,7 @@ public:
     /*
      * Initialize and return singleton.
      */
-    static Mainloop &init(const Configuration &configuration);
+    static Mainloop &init();
 
     /*
      * De-initialize singleton so we can start a fresh on the same


### PR DESCRIPTION
When USB endpoints are not available during startup of MR, it fails with fatal error and exits.
Also, when USB is disconnected during operation, it fails and exit.

IMO starting without configured endpoint might be argued, but failing during operation and exiting may lead to severe consequences.

Also, this PR is a starting point for next feature - recovery from USB failures. Mainloop could poll disabled endpoints and enable them once are back again.

PR applies to USB only, because I did not test TCP endpoints that can also fail due to TCP's nature.
Also, UDP could fail if configured to bind on non existing local IP (net changed OR cable fail thus not bringing eth itf up). This also can be supported in next PRs.

Consider my PR. I got what I wanted in my fork, but if you find this valuable, I'd be happy to contribute.