### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,3 +144,52 @@ jobs:
           tag: ${{ github.ref }}
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           overwrite: true
+
+  macos:
+    name: macOS (aarch64)
+    runs-on: macos-latest
+    needs: [formatting-check]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0  # otherwise the version header just contains the commit hash
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install meson ninja pkg-config googletest epoll-shim
+          pip3 install pymavlink --break-system-packages --user
+
+      - name: Configure
+        run: meson setup --werror build .
+
+      - name: Build
+        run: ninja -C build
+
+      - name: Test
+        run: ninja -C build test
+
+      - name: Install
+        run: DESTDIR=./.debpkg ninja -C build install
+
+      - name: Run routing_test.py
+        run: python3 ./tests/routing_test.py -b ./build/src/mavlink-routerd
+
+      - name: Rename binary
+        run: cp build/src/mavlink-routerd build/src/mavlink-routerd-macos-arm64
+
+      - uses: actions/upload-artifact@master
+        with:
+          path: build/src/mavlink-routerd-macos-arm64
+          name: mavlink-routerd-macos-arm64
+
+      - uses: svenstaro/upload-release-action@v2
+        name: Upload binaries to release
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/src/mavlink-routerd-macos-arm64
+          tag: ${{ github.ref }}
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+          overwrite: true

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Archlinux:
 
     $ sudo pacman -S git meson gcc systemd
 
+macOS:
+
+    $ brew install meson ninja pkg-config epoll-shim
+
 Note that meson package must be version 0.55 or later. If your package manager
 does not have this version, a more recent version can be downloaded via pip:
 

--- a/examples/heartbeat-print.cpp
+++ b/examples/heartbeat-print.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
     }
 
     char *ip = strdup(argv[1]);
-    char *portstr = strchrnul(ip, ':');
+    char *portstr = strchr(ip, ':');
     if (portstr && *portstr) {
         *portstr = '\0';
         port = atoi(portstr + 1);

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,18 +1,22 @@
 exe_arm_authorizer = executable('arm-authorizer',
         ['arm-authorizer.cpp'],
         include_directories: [mavlink_inc, src_inc],
+        dependencies: deps_platform,
         install: false,
 )
 
 heartbeat_print = executable('heartbeat-print',
         ['heartbeat-print.cpp'],
         include_directories: [mavlink_inc, src_inc],
+        dependencies: deps_platform,
         install: false,
 )
 
 px4_offboard_mode = executable('px4-offboard-mode',
         ['px4-offboard-mode.cpp'],
         include_directories: [mavlink_inc, src_inc],
+        dependencies: deps_platform,
         link_with: libcommon_private,
         install: false,
 )
+

--- a/examples/px4-offboard-mode.cpp
+++ b/examples/px4-offboard-mode.cpp
@@ -36,6 +36,7 @@
  */
 
 #include <arpa/inet.h>
+#include <common/time_compat.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
@@ -45,7 +46,6 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/timerfd.h>
-#include <time.h>
 #include <unistd.h>
 
 #include <common/mavlink.h>
@@ -651,7 +651,7 @@ int main(int argc, char *argv[])
     if (argc > 1) {
         free(ip);
         ip = strdup(argv[1]);
-        char *portstr = strchrnul(ip, ':');
+        char *portstr = strchr(ip, ':');
         if (portstr && *portstr) {
             *portstr = '\0';
             port = atoi(portstr + 1);

--- a/meson-cross-aarch64.ini
+++ b/meson-cross-aarch64.ini
@@ -8,6 +8,13 @@ ar = arch + '-linux-gnu-gcc-ar'
 strip = arch + '-linux-gnu-strip'
 pkgconfig = 'pkg-config'
 
+[built-in options]
+# Workaround for failing builds due to google test:
+# /rootfs/usr/src/gtest/include/gtest/gtest-printers.h:557:21: error: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Werror=float-equal]
+# /rootfs/usr/src/gtest/src/gtest-death-test.cc:515:6: error: function might be candidate for attribute ‘noreturn’ [-Werror=suggest-attribute=noreturn]
+c_args = ['-Wno-float-equal', '-Wno-missing-noreturn']
+cpp_args = ['-Wno-float-equal', '-Wno-missing-noreturn']
+
 [host_machine]
 system = 'linux'
 cpu_family = 'aarch64'

--- a/meson-cross-armhf.ini
+++ b/meson-cross-armhf.ini
@@ -9,6 +9,13 @@ strip = arch + '-linux-gnueabihf-strip'
 pkgconfig = 'pkg-config'
 #exe_wrapper = 'qemu-' + arch + '-static'
 
+[built-in options]
+# Workaround for failing builds due to google test:
+# /rootfs/usr/src/gtest/include/gtest/gtest-printers.h:557:21: error: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Werror=float-equal]
+# /rootfs/usr/src/gtest/src/gtest-death-test.cc:515:6: error: function might be candidate for attribute ‘noreturn’ [-Werror=suggest-attribute=noreturn]
+c_args = ['-Wno-float-equal', '-Wno-missing-noreturn']
+cpp_args = ['-Wno-float-equal', '-Wno-missing-noreturn']
+
 [host_machine]
 system = 'linux'
 cpu_family = 'arm'

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
         version: '3',
         license: 'Apache 2.0',
         default_options: [
-                'cpp_std=gnu++14',
+                'cpp_std=gnu++17',
                 'prefix=/usr',
                 'warning_level=2',
                 'buildtype=debugoptimized',
@@ -24,15 +24,23 @@ cc = meson.get_compiler('c')
 
 # Mandatory dependencies
 dep_math = cxx.find_library('m')
-dep_rt = cxx.find_library('rt')
+
 dep_thread = dependency('threads')
 
-# Optional dependencies
-systemd_system_unit_dir = get_option('systemdsystemunitdir')
-if systemd_system_unit_dir == 'auto'
-		dep_systemd = dependency('systemd')
-		systemd_system_unit_dir = dep_systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
-endif
+deps_platform = []
+
+if host_machine.system() != 'darwin'
+        deps_platform += cxx.find_library('rt')
+        # Optional dependencies
+        systemd_system_unit_dir = get_option('systemdsystemunitdir')
+        if systemd_system_unit_dir == 'auto'
+                dep_systemd = dependency('systemd')
+                systemd_system_unit_dir = dep_systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+        endif
+else
+    dep_epoll_shim = dependency('epoll-shim-interpose', required: true)
+    deps_platform += dep_epoll_shim
+endif 
 
 dep_gtest = dependency('gtest', main : true, required : false)
 
@@ -128,12 +136,14 @@ mavlink_inc = include_directories('modules/mavlink_c_library_v2/ardupilotmega')
 src_inc = include_directories('src')
 
 # Additonal data to be installed
-configure_file(
-        input: 'mavlink-router.service.in',
-        output: 'mavlink-router.service',
-        configuration: conf,
-        install_dir: systemd_system_unit_dir,
-)
+if host_machine.system() != 'darwin'
+        configure_file(
+                input: 'mavlink-router.service.in',
+                output: 'mavlink-router.service',
+                configuration: conf,
+                install_dir: systemd_system_unit_dir,
+        )
+endif
 
 subdir('src')
 subdir('examples')

--- a/src/comm.h
+++ b/src/comm.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <arpa/inet.h>
-#include <asm/termbits.h>
 #include <errno.h>
 #include <inttypes.h>
 

--- a/src/common/endian_compat.h
+++ b/src/common/endian_compat.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef __APPLE__
+#    include <endian.h>
+#else
+#    include <libkern/OSByteOrder.h>
+#    ifndef htobe64
+#        define htobe64(x) OSSwapHostToBigInt64(x)
+#    endif
+#endif

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -1,9 +1,21 @@
+src_platform = []
+if host_machine.system() != 'darwin'
+        src_platform = [
+         'xtermios.cpp', 
+         'serial_linux.cpp'
+        ]
+else
+        src_platform = [
+         'serial_macos.cpp'
+        ]
+endif 
+
 libcommon_private = static_library('common-private',
-        [
+        src_platform + [
          'conf_file.cpp',
          'log.cpp',
          'util.cpp',
-         'xtermios.cpp',
+         
         ],
         pic: true,
         install: false,

--- a/src/common/serial.h
+++ b/src/common/serial.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
+int init_serial(int fd, const char *path);
+int set_serial_speed(int fd, uint32_t baudrate);
+int set_serial_flow_control(int fd, bool enabled);

--- a/src/common/serial_linux.cpp
+++ b/src/common/serial_linux.cpp
@@ -1,0 +1,145 @@
+#include "log.h"
+#include "serial.h"
+#include "xtermios.h"
+
+#include <asm/ioctls.h>
+#include <asm/termbits.h>
+#include <linux/serial.h>
+#include <sys/ioctl.h>
+
+int init_serial(int fd, const char *path)
+{
+    int ret = 0;
+    ret = reset_uart(fd);
+    if (ret < 0) {
+        log_error("Could not reset uart on %s", path);
+        return ret;
+    }
+
+    struct termios2 tc = {};
+
+    ret = ioctl(fd, TCGETS2, &tc);
+    if (ret < 0) {
+        log_error("Could not get termios2 on %s (%m)", path);
+        return ret;
+    }
+
+    tc.c_iflag &= ~(IGNBRK | BRKINT | ICRNL | INLCR | PARMRK | INPCK | ISTRIP | IXON);
+    tc.c_oflag &= ~(OCRNL | ONLCR | ONLRET | ONOCR | OFILL | OPOST);
+
+    tc.c_lflag &= ~(ECHO | ECHOE | ECHOK | ECHOCTL | ECHOKE | ECHONL | ICANON | IEXTEN | ISIG);
+
+    /* never send SIGTTOU*/
+    tc.c_lflag &= ~(TOSTOP);
+
+    /* disable flow control */
+    tc.c_cflag &= ~(CRTSCTS);
+    tc.c_cflag &= ~(CSIZE | PARENB);
+
+    /* ignore modem control lines */
+    tc.c_cflag |= CLOCAL;
+
+    /* 8 bits */
+    tc.c_cflag |= CS8;
+
+    /* we use epoll to get notification of available bytes */
+    tc.c_cc[VMIN] = 0;
+    tc.c_cc[VTIME] = 0;
+
+    ret = ioctl(fd, TCSETS2, &tc);
+    if (ret < 0) {
+        log_error("Could not set terminal attributes on %s (%m)", path);
+        return ret;
+    }
+
+    // For Linux, set high speed polling at the chip
+    // level. Since this routine relies on a USB latency
+    // change at the chip level it may fail on certain
+    // chip sets if their driver does not support this
+    // configuration request
+
+    {
+        struct serial_struct serial_ctl;
+
+        ret = ioctl(fd, TIOCGSERIAL, &serial_ctl);
+        if (ret < 0) {
+            log_warning("Error while trying to read serial port configuration on %s: %m", path);
+        } else {
+            serial_ctl.flags |= ASYNC_LOW_LATENCY;
+
+            ret = ioctl(fd, TIOCSSERIAL, &serial_ctl);
+            if (ret < 0) {
+                if (errno != ENODEV && errno != ENOTTY) {
+                    log_warning("Error while trying to write serial port latency on %s: %m", path);
+                }
+            }
+        }
+    }
+
+    ret = ioctl(fd, TCFLSH, TCIOFLUSH);
+    if (ret < 0) {
+        log_error("Could not flush terminal on %s (%m)", path);
+        return ret;
+    }
+
+    return 0;
+}
+
+int set_serial_speed(int fd, uint32_t baudrate)
+{
+    if (fd < 0) {
+        return -1;
+    }
+
+    struct termios2 tc = {};
+
+    if (ioctl(fd, TCGETS2, &tc) == -1) {
+        log_error("Could not get termios2 (%m)");
+        return -1;
+    }
+
+    /* speed is configured by c_[io]speed */
+    tc.c_cflag &= ~CBAUD;
+    tc.c_cflag |= BOTHER;
+    tc.c_ispeed = baudrate;
+    tc.c_ospeed = baudrate;
+
+    if (ioctl(fd, TCSETS2, &tc) == -1) {
+        log_error("Could not set terminal attributes (%m)");
+        return -1;
+    }
+
+    if (ioctl(fd, TCFLSH, TCIOFLUSH) == -1) {
+        log_error("Could not flush terminal (%m)");
+        return -1;
+    }
+
+    return 0;
+}
+
+int set_serial_flow_control(int fd, bool enabled)
+{
+    if (fd < 0) {
+        return -1;
+    }
+
+    struct termios2 tc = {};
+
+    if (ioctl(fd, TCGETS2, &tc) == -1) {
+        log_error("Could not get termios2 (%m)");
+        return -1;
+    }
+
+    if (enabled) {
+        tc.c_cflag |= CRTSCTS;
+    } else {
+        tc.c_cflag &= ~CRTSCTS;
+    }
+
+    if (ioctl(fd, TCSETS2, &tc) == -1) {
+        log_error("Could not set terminal attributes (%m)");
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/common/serial_macos.cpp
+++ b/src/common/serial_macos.cpp
@@ -1,0 +1,81 @@
+#include "serial.h"
+#include <IOKit/serial/ioss.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+
+int init_serial(int fd, const char *path)
+{
+    struct termios tty = {};
+
+    int ret = tcgetattr(fd, &tty);
+    if (ret < 0) {
+        return ret;
+    }
+
+    // Input flags
+    tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL);
+    tty.c_iflag &= ~(IXON | IXOFF); // No software flow control
+    tty.c_iflag &= ~INPCK;          // No parity checking
+    tty.c_iflag |= IGNPAR;          // Ignore parity errors
+
+    // Output flags
+    tty.c_oflag &= ~OPOST; // No post processing
+
+    // Control flags
+    tty.c_cflag |= (CLOCAL | CREAD);   // Enable receiver, ignore modem control lines
+    tty.c_cflag &= ~(PARENB | PARODD); // No parity
+    tty.c_cflag &= ~CSTOPB;            // 1 stop bit
+    tty.c_cflag &= ~CRTSCTS;           // No hardware flow control
+    tty.c_cflag &= ~CSIZE;             // Clear data size bits
+    tty.c_cflag |= CS8;                // 8 data bits
+
+    // Local flags
+    tty.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+
+    // Control characters
+    tty.c_cc[VMIN] = 0;  // Non-blocking read
+    tty.c_cc[VTIME] = 0; // No timeout
+
+    ret = tcsetattr(fd, TCSANOW, &tty);
+    if (ret < 0) {
+        return ret;
+    }
+
+    tcflush(fd, TCIOFLUSH);
+
+    return 0;
+}
+
+int set_serial_speed(int fd, uint32_t baudrate)
+{
+    speed_t speed = static_cast<speed_t>(baudrate);
+
+    int ret = ioctl(fd, IOSSIOSPEED, &speed);
+    if (ret < 0) {
+        return ret;
+    }
+    return 0;
+}
+
+int set_serial_flow_control(int fd, bool enabled)
+{
+    struct termios tty = {};
+
+    int ret = tcgetattr(fd, &tty);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (enabled) {
+        tty.c_cflag |= CRTSCTS;
+    } else {
+        tty.c_cflag &= ~CRTSCTS;
+    }
+
+    ret = tcsetattr(fd, TCSANOW, &tty);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}

--- a/src/common/socket_compat.h
+++ b/src/common/socket_compat.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <sys/socket.h>
+
+#ifdef __APPLE__
+#    ifndef IPV6_ADD_MEMBERSHIP
+#        define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
+#    endif
+#endif

--- a/src/common/time_compat.h
+++ b/src/common/time_compat.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <time.h>
+
+#ifdef __APPLE__
+
+struct itimerspec {
+    struct timespec it_interval;
+    struct timespec it_value;
+};
+
+#endif

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -65,6 +65,4 @@ template <typename type> bool vector_contains(std::vector<type> vect, type elem)
             __out[__len] = '\0';                     \
             (char *)memcpy(__out, __in, __len);      \
         }))
-
-#    include <asm/ioctls.h>
 #endif

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -307,9 +307,9 @@ public:
 
 protected:
     bool open(const char *path);
-    int set_speed(speed_t baudrate);
+    int set_speed(uint32_t baudrate);
     int set_flow_control(bool enabled);
-    int add_speeds(const std::vector<speed_t> &bauds);
+    int add_speeds(const std::vector<uint32_t> &bauds);
 
     int read_msg(struct buffer *pbuf) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -627,9 +627,9 @@ TEST_P(UdpEndpointConfigPortTestFixture, UdpPortRangeCheck)
         << "with port " << std::to_string(config.port);
 }
 
-INSTANTIATE_TEST_CASE_P(UdpEndpointTest, UdpEndpointConfigPortTestFixture,
-                        ::testing::Values(UdpEndpointConfig::Mode::Client,
-                                          UdpEndpointConfig::Mode::Server));
+INSTANTIATE_TEST_SUITE_P(UdpEndpointTest, UdpEndpointConfigPortTestFixture,
+                         ::testing::Values(UdpEndpointConfig::Mode::Client,
+                                           UdpEndpointConfig::Mode::Server));
 
 TEST(UdpEndpointTest, ConfigValidateMode)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,10 @@
 
 extern const char *BUILD_VERSION;
 
+#ifdef __APPLE__
+const char *program_invocation_short_name = "mavlink-routerd";
+#endif
+
 static const struct option long_options[] = {{"endpoints", required_argument, nullptr, 'e'},
                                              {"conf-file", required_argument, nullptr, 'c'},
                                              {"conf-dir", required_argument, nullptr, 'd'},

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,9 +17,9 @@ exe_mavlink_router = executable('mavlink-routerd',
          version_h,
         ],
         include_directories: [src_inc, mavlink_inc],
-        dependencies: [
+        dependencies: deps_platform + 
+        [
                 dep_math,
-                dep_rt,
                 dep_thread,
         ],
         link_with: libcommon_private,
@@ -43,9 +43,9 @@ if dep_gtest.found()
             version_h,
           ],
           include_directories: [src_inc, mavlink_inc],
-          dependencies : [
+          dependencies : deps_platform + 
+          [
             dep_gtest,
-            dep_rt,
           ],
           link_with: libcommon_private,
           install: false,
@@ -68,12 +68,13 @@ if dep_gtest.found()
             version_h,
           ],
           include_directories: [src_inc, mavlink_inc],
-          dependencies : [
+          dependencies : deps_platform + 
+          [
             dep_gtest,
-            dep_rt,
           ],
           link_with: libcommon_private,
           install: false,
   )
   test('endpoints', exe_endpoints_test)
 endif
+

--- a/src/tlog.cpp
+++ b/src/tlog.cpp
@@ -18,7 +18,7 @@
 #include "tlog.h"
 
 #include <assert.h>
-#include <endian.h>
+#include <common/endian_compat.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/tools/ci-create-rootfs.sh
+++ b/tools/ci-create-rootfs.sh
@@ -15,6 +15,6 @@ DISTRO="ubuntu:24.04"
 
 	podman build --arch $ARCH --from docker.io/$DISTRO -t $ARCH-rootfs $SCRIPT_DIR
 	container=$(podman run --arch $ARCH -d $ARCH-rootfs)
-} >/dev/null
+} >&2
 
 podman export $container


### PR DESCRIPTION
- Add macOS build instructions to README.md
- Require gnu++17 standard (enforced by googletest on macOS)
- Add platform compatibility headers, update meson build
- Move serial implementation to platform-specific files
- Update to use cross-platform functions - socket4 -> socket, strchrnul -> strchr
- Add CI job for macOS aarch64 builds
- Workaround failing armhf and aarch64 builds due to googletest warnings