### PR TITLE
C++ version bump

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
         version: '3',
         license: 'Apache 2.0',
         default_options: [
-                'cpp_std=gnu++14',
+                'cpp_std=gnu++17',
                 'prefix=/usr',
                 'warning_level=2',
                 'buildtype=debugoptimized',


### PR DESCRIPTION
Update C++ standard from C++14 to C++17.

On version 14 compilation failed because of gtest library: 
```
In file included from /usr/include/gtest/gtest-message.h:57,
                 from /usr/include/gtest/gtest-assertion-result.h:46,
                 from /usr/include/gtest/gtest.h:63,
                 from ../src/endpoints_test.cpp:27:
/usr/include/gtest/internal/gtest-port.h:273:2: error: #error C++ versions less than C++17 are not supported.
  273 | #error C++ versions less than C++17 are not supported.
      |  ^~~~~
In file included from /usr/include/gtest/gtest.h:67:
/usr/include/gtest/gtest-param-test.h:483:56: error: missing template arguments before '(' token
  483 |           typename StdFunction = decltype(std::function(std::declval<Func>()))>
      |                                                        ^
/usr/include/gtest/gtest-param-test.h:493:56: error: missing template arguments before '(' token
  493 |           typename StdFunction = decltype(std::function(std::declval<Func>()))>
      |       
```

Compiling it with 17-th version fixed the issue.
FYI, it also compiled fine with version 26, but I'll leave it up to you to decide