### PR TITLE
Filters for throttling message rates to specific Endpoints

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -610,15 +610,6 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         }
     }
 
-    // If filter is defined and message is in the set and should be dropped based on throttling: discard it
-    if (!_msg_and_rate_map.empty()) {
-        const uint64_t now_ms = _now_monotonic_ms();
-        if (!_rate_limit_allows(pbuf->curr.msg_id, now_ms)) {
-            log_trace("%s: Throttled MsgId %u", _name.c_str(), pbuf->curr.msg_id);
-            return Endpoint::AcceptState::Filtered;
-        }
-    }
-
     // Message is broadcast on sysid or sysid is non-existent: accept msg
     if (pbuf->curr.target_sysid == 0 || pbuf->curr.target_sysid == -1) {
         return Endpoint::AcceptState::Accepted;

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -73,8 +73,8 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
     // New: throttle args
-    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
-    {"RateLimitPeriodMsOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
+    {"ThrottleLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
+    {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
 
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
@@ -99,8 +99,8 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
         // New: throttle args
-    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
-    {"RateLimitPeriodMsOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
+    {"ThrottleLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_msg_id_out)},
+    {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -123,8 +123,8 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
         // New: throttle args
-    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
-    {"RateLimitPeriodMsOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
+    {"ThrottleLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_msg_id_out)},
+    {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -846,7 +846,7 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
         this->filter_add_blocked_in_src_sys(src_sys);
     }
     if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("UartEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodMsOut length mismatch",
+        log_warning("UartEndpoint %s: ThrottleLimitMsgIdOut and ThrottledMsgPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
@@ -1191,7 +1191,7 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
         this->filter_add_blocked_in_src_sys(src_sys);
     }
     if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("UdpEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodMsOut length mismatch",
+        log_warning("UdpEndpoint %s: ThrottleLimitMsgIdOut and ThrottledMsgPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
@@ -1574,7 +1574,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
         this->filter_add_blocked_in_src_sys(src_sys);
     }
     if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("TcpEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodMsOut length mismatch",
+        log_warning("TcpEndpoint %s: ThrottleLimitMsgIdOut and ThrottledMsgPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -72,10 +72,8 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
-    // New: throttle args
     {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
     {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
-
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
@@ -98,7 +96,6 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
-        // New: throttle args
     {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_msg_id_out)},
     {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
@@ -122,7 +119,6 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
-        // New: throttle args
     {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_msg_id_out)},
     {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
@@ -245,7 +241,7 @@ bool Endpoint::_rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const
     return is_allowed;
 }
 
-void Endpoint::_rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms)
+void Endpoint::_rate_limit_record_msg_sent(uint32_t msg_id, uint64_t now_ms)
 {
     if (msg_id == UINT32_MAX) {
         return; // not valid
@@ -281,7 +277,7 @@ bool Endpoint::_rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const
     return is_allowed;
 }
 
-void Endpoint::_rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms)
+void Endpoint::_rate_limit_record_msg_sent(uint32_t msg_id, uint64_t now_ms)
 {
     if (msg_id == UINT32_MAX) {
         return; // not valid
@@ -1130,12 +1126,9 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
                   _name.c_str(),
                   r,
                   pbuf->len);
-    } else {
+    }else {
         // Record message sent time for rate limiting
-        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
-    } else {
-        // Record message sent time for rate limiting
-        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
+        _rate_limit_record_msg_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
 
     log_trace("UART [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);
@@ -1496,12 +1489,8 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
                   pbuf->len);
     }else {
         // Record message sent time for rate limiting
-        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
-    }else {
-        // Record message sent time for rate limiting
-        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
+        _rate_limit_record_msg_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
-
     log_trace("UDP [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);
 
     return r;
@@ -1869,10 +1858,7 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
                   pbuf->len);
     }else {
         // Record message sent time for rate limiting
-        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
-    }else {
-        // Record message sent time for rate limiting
-        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
+        _rate_limit_record_msg_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
 
     log_trace("TCP [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -72,6 +72,10 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
+    // New: throttle args
+    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
+    {"RateLimitPeriodMsOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
+
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
@@ -94,6 +98,9 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
+        // New: throttle args
+    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
+    {"RateLimitPeriodMsOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -115,6 +122,9 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
+        // New: throttle args
+    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
+    {"RateLimitPeriodMsOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -210,6 +220,42 @@ Endpoint::~Endpoint()
     free(rx_buf.data);
     free(tx_buf.data);
 }
+
+uint64_t Endpoint::_now_monotonic_ms()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec) * 1000ULL
+           + static_cast<uint64_t>(ts.tv_nsec / 1000000ULL);
+}
+
+bool Endpoint::_rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const
+{
+    auto throttled_msg = _msg_and_rate_map.find(msg_id);
+    if (throttled_msg == _msg_and_rate_map.end()) {
+        return true; // no throttle configured
+    }
+    const uint32_t msg_rate_ms = throttled_msg->second;
+    auto last_throttled_msg = _throttled_msgs_last_send.find(msg_id);
+   if (last_throttled_msg == _throttled_msgs_last_send.end()) {
+       return true; // not yet sent
+    }
+    const uint64_t elapsed = (now_ms >= last_throttled_msg->second) ? (now_ms - last_throttled_msg->second) : 0ULL;
+    bool is_allowed=elapsed >= static_cast<uint64_t>(msg_rate_ms);
+    return is_allowed;
+}
+
+void Endpoint::_rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms)
+{
+    if (msg_id == UINT32_MAX) {
+        return; // not valid
+    }
+    if (_msg_and_rate_map.find(msg_id) == _msg_and_rate_map.end()) {
+        return; // not tracked
+    }
+   _throttled_msgs_last_send[msg_id] = now_ms; // record last sent time
+}
+
 
 bool Endpoint::handle_canwrite()
 {
@@ -559,6 +605,15 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         return Endpoint::AcceptState::Filtered;
     }
 
+    // If filter is defined and message is in the set and should be dropped based on throttling: discard it
+    if (!_msg_and_rate_map.empty()) {
+        const uint64_t now_ms = _now_monotonic_ms();
+        if (!_rate_limit_allows(pbuf->curr.msg_id, now_ms)) {
+            log_trace("%s: Throttled MsgId %u", _name.c_str(), pbuf->curr.msg_id);
+            return Endpoint::AcceptState::Filtered;
+        }
+    }
+
     // Message is broadcast on sysid or sysid is non-existent: accept msg
     if (pbuf->curr.target_sysid == 0 || pbuf->curr.target_sysid == -1) {
         return Endpoint::AcceptState::Accepted;
@@ -789,6 +844,14 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     }
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
+    }
+    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
+        log_warning("UartEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodMsOut length mismatch",
+                    conf.name.c_str());
+    } else {
+        for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
+            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_ms_out[i]);
+       }
     }
 
     this->_group_name = conf.group;
@@ -1022,6 +1085,9 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
                   _name.c_str(),
                   r,
                   pbuf->len);
+    } else {
+        // Record message sent time for rate limiting
+        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
 
     log_trace("UART [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);
@@ -1123,6 +1189,14 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     }
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
+    }
+    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
+        log_warning("UdpEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodMsOut length mismatch",
+                    conf.name.c_str());
+    } else {
+        for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
+            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_ms_out[i]);
+       }
     }
 
     this->_group_name = conf.group;
@@ -1372,6 +1446,9 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
                   _name.c_str(),
                   r,
                   pbuf->len);
+    }else {
+        // Record message sent time for rate limiting
+        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
 
     log_trace("UDP [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);
@@ -1495,6 +1572,14 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     }
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
+    }
+    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
+        log_warning("TcpEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodMsOut length mismatch",
+                    conf.name.c_str());
+    } else {
+        for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
+            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_ms_out[i]);
+       }
     }
 
     this->_group_name = conf.group;
@@ -1731,6 +1816,9 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
                   _name.c_str(),
                   r,
                   pbuf->len);
+    }else {
+        // Record message sent time for rate limiting
+        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
 
     log_trace("TCP [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -257,6 +257,42 @@ void Endpoint::_rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms)
 }
 
 
+uint64_t Endpoint::_now_monotonic_ms()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec) * 1000ULL
+           + static_cast<uint64_t>(ts.tv_nsec / 1000000ULL);
+}
+
+bool Endpoint::_rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const
+{
+    auto throttled_msg = _msg_and_rate_map.find(msg_id);
+    if (throttled_msg == _msg_and_rate_map.end()) {
+        return true; // no throttle configured
+    }
+    const uint32_t msg_rate_ms = throttled_msg->second;
+    auto last_throttled_msg = _throttled_msgs_last_send.find(msg_id);
+   if (last_throttled_msg == _throttled_msgs_last_send.end()) {
+       return true; // not yet sent
+    }
+    const uint64_t elapsed = (now_ms >= last_throttled_msg->second) ? (now_ms - last_throttled_msg->second) : 0ULL;
+    bool is_allowed=elapsed >= static_cast<uint64_t>(msg_rate_ms);
+    return is_allowed;
+}
+
+void Endpoint::_rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms)
+{
+    if (msg_id == UINT32_MAX) {
+        return; // not valid
+    }
+    if (_msg_and_rate_map.find(msg_id) == _msg_and_rate_map.end()) {
+        return; // not tracked
+    }
+   _throttled_msgs_last_send[msg_id] = now_ms; // record last sent time
+}
+
+
 bool Endpoint::handle_canwrite()
 {
     int r = flush_pending_msgs();
@@ -603,6 +639,15 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
     if (pbuf->curr.msg_id != UINT32_MAX && !_blocked_outgoing_src_systems.empty()
         && vector_contains(_blocked_outgoing_src_systems, pbuf->curr.src_sysid)) {
         return Endpoint::AcceptState::Filtered;
+    }
+
+    // If filter is defined and message is in the set and should be dropped based on throttling: discard it
+    if (!_msg_and_rate_map.empty()) {
+        const uint64_t now_ms = _now_monotonic_ms();
+        if (!_rate_limit_allows(pbuf->curr.msg_id, now_ms)) {
+            log_trace("%s: Throttled MsgId %u", _name.c_str(), pbuf->curr.msg_id);
+            return Endpoint::AcceptState::Filtered;
+        }
     }
 
     // If filter is defined and message is in the set and should be dropped based on throttling: discard it
@@ -1088,6 +1133,9 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
     } else {
         // Record message sent time for rate limiting
         _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
+    } else {
+        // Record message sent time for rate limiting
+        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }
 
     log_trace("UART [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);
@@ -1446,6 +1494,9 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
                   _name.c_str(),
                   r,
                   pbuf->len);
+    }else {
+        // Record message sent time for rate limiting
+        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }else {
         // Record message sent time for rate limiting
         _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
@@ -1816,6 +1867,9 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
                   _name.c_str(),
                   r,
                   pbuf->len);
+    }else {
+        // Record message sent time for rate limiting
+        _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());
     }else {
         // Record message sent time for rate limiting
         _rate_limit_mark_sent(pbuf->curr.msg_id, _now_monotonic_ms());

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -72,8 +72,8 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
-    {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
-    {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
+    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
+    {"RateLimitPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_out)},
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
     {}
 };
@@ -96,8 +96,8 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
-    {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_msg_id_out)},
-    {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_period_ms_out)},
+    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_msg_id_out)},
+    {"RateLimitPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_period_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
 };
@@ -119,8 +119,8 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"BlockSrcCompIn",  false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_comp_in)},
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
-    {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_msg_id_out)},
-    {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_period_ms_out)},
+    {"RateLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_msg_id_out)},
+    {"RateLimitPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_period_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
 };
@@ -216,42 +216,6 @@ Endpoint::~Endpoint()
     free(rx_buf.data);
     free(tx_buf.data);
 }
-
-uint64_t Endpoint::_now_monotonic_ms()
-{
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return static_cast<uint64_t>(ts.tv_sec) * 1000ULL
-           + static_cast<uint64_t>(ts.tv_nsec / 1000000ULL);
-}
-
-bool Endpoint::_rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const
-{
-    auto throttled_msg = _msg_and_rate_map.find(msg_id);
-    if (throttled_msg == _msg_and_rate_map.end()) {
-        return true; // no throttle configured
-    }
-    const uint32_t msg_rate_ms = throttled_msg->second;
-    auto last_throttled_msg = _throttled_msgs_last_send.find(msg_id);
-   if (last_throttled_msg == _throttled_msgs_last_send.end()) {
-       return true; // not yet sent
-    }
-    const uint64_t elapsed = (now_ms >= last_throttled_msg->second) ? (now_ms - last_throttled_msg->second) : 0ULL;
-    bool is_allowed=elapsed >= static_cast<uint64_t>(msg_rate_ms);
-    return is_allowed;
-}
-
-void Endpoint::_rate_limit_record_msg_sent(uint32_t msg_id, uint64_t now_ms)
-{
-    if (msg_id == UINT32_MAX) {
-        return; // not valid
-    }
-    if (_msg_and_rate_map.find(msg_id) == _msg_and_rate_map.end()) {
-        return; // not tracked
-    }
-   _throttled_msgs_last_send[msg_id] = now_ms; // record last sent time
-}
-
 
 uint64_t Endpoint::_now_monotonic_ms()
 {
@@ -886,12 +850,12 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
     }
-    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("UartEndpoint %s: ThrottleMsgIdOut and ThrottledMsgPeriodOut length mismatch",
+    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_out.size()) {
+        log_warning("UartEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
-            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_ms_out[i]);
+            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_out[i]);
        }
     }
 
@@ -1231,12 +1195,12 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
     }
-    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("UdpEndpoint %s: ThrottleMsgIdOut and ThrottledMsgPeriodOut length mismatch",
+    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_out.size()) {
+        log_warning("UdpEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
-            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_ms_out[i]);
+            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_out[i]);
        }
     }
 
@@ -1613,12 +1577,12 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     for (auto src_sys : conf.block_src_sys_in) {
         this->filter_add_blocked_in_src_sys(src_sys);
     }
-    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("TcpEndpoint %s: ThrottleMsgIdOut and ThrottledMsgPeriodOut length mismatch",
+    if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_out.size()) {
+        log_warning("TcpEndpoint %s: RateLimitMsgIdOut and RateLimitPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
-            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_ms_out[i]);
+            this->rate_limit_set(conf.rate_limit_msg_id_out[i], conf.rate_limit_period_out[i]);
        }
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -73,7 +73,7 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
     // New: throttle args
-    {"ThrottleLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
+    {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_msg_id_out)},
     {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, rate_limit_period_ms_out)},
 
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
@@ -99,7 +99,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_src_sys_in)},
         // New: throttle args
-    {"ThrottleLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_msg_id_out)},
+    {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_msg_id_out)},
     {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, group)},
     {}
@@ -123,7 +123,7 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false,  ConfFile::parse_uint8_vector,   OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_src_sys_in)},
         // New: throttle args
-    {"ThrottleLimitMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_msg_id_out)},
+    {"ThrottleMsgIdOut",     false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_msg_id_out)},
     {"ThrottledMsgPeriodOut",  false, ConfFile::parse_uint32_vector, OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, rate_limit_period_ms_out)},
     {"group",           false,  ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, group)},
     {}
@@ -891,7 +891,7 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
         this->filter_add_blocked_in_src_sys(src_sys);
     }
     if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("UartEndpoint %s: ThrottleLimitMsgIdOut and ThrottledMsgPeriodOut length mismatch",
+        log_warning("UartEndpoint %s: ThrottleMsgIdOut and ThrottledMsgPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
@@ -1239,7 +1239,7 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
         this->filter_add_blocked_in_src_sys(src_sys);
     }
     if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("UdpEndpoint %s: ThrottleLimitMsgIdOut and ThrottledMsgPeriodOut length mismatch",
+        log_warning("UdpEndpoint %s: ThrottleMsgIdOut and ThrottledMsgPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {
@@ -1625,7 +1625,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
         this->filter_add_blocked_in_src_sys(src_sys);
     }
     if (conf.rate_limit_msg_id_out.size() != conf.rate_limit_period_ms_out.size()) {
-        log_warning("TcpEndpoint %s: ThrottleLimitMsgIdOut and ThrottledMsgPeriodOut length mismatch",
+        log_warning("TcpEndpoint %s: ThrottleMsgIdOut and ThrottledMsgPeriodOut length mismatch",
                     conf.name.c_str());
     } else {
         for (size_t i = 0; i < conf.rate_limit_msg_id_out.size(); ++i) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -54,7 +54,7 @@ struct UartEndpointConfig {
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
     std::vector<uint32_t> rate_limit_msg_id_out;
-    std::vector<uint32_t> rate_limit_period_ms_out;
+    std::vector<uint32_t> rate_limit_period_out;
     std::string group;
 };
 
@@ -78,7 +78,7 @@ struct UdpEndpointConfig {
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
     std::vector<uint32_t> rate_limit_msg_id_out;
-    std::vector<uint32_t> rate_limit_period_ms_out;
+    std::vector<uint32_t> rate_limit_period_out;
     std::string group;
 };
 
@@ -100,7 +100,7 @@ struct TcpEndpointConfig {
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
     std::vector<uint32_t> rate_limit_msg_id_out;
-    std::vector<uint32_t> rate_limit_period_ms_out;
+    std::vector<uint32_t> rate_limit_period_out;
     std::string group;
 };
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -19,7 +19,7 @@
 
 #include <common/conf_file.h>
 #include <common/mavlink.h>
-
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -53,6 +53,8 @@ struct UartEndpointConfig {
     std::vector<uint8_t> block_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
+    std::vector<uint32_t> rate_limit_msg_id_out;
+    std::vector<uint32_t> rate_limit_period_ms_out;
     std::string group;
 };
 
@@ -75,6 +77,8 @@ struct UdpEndpointConfig {
     std::vector<uint8_t> block_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
+    std::vector<uint32_t> rate_limit_msg_id_out;
+    std::vector<uint32_t> rate_limit_period_ms_out;
     std::string group;
 };
 
@@ -95,6 +99,8 @@ struct TcpEndpointConfig {
     std::vector<uint8_t> block_src_comp_in;
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
+    std::vector<uint32_t> rate_limit_msg_id_out;
+    std::vector<uint32_t> rate_limit_period_ms_out;
     std::string group;
 };
 
@@ -228,6 +234,10 @@ public:
         _blocked_incoming_src_systems.push_back(src_sys);
     }
 
+   void rate_limit_set(uint32_t msg_id, uint32_t period_ms) {
+       _msg_and_rate_map[msg_id] = period_ms;
+   }
+
     bool allowed_by_dedup(const buffer *pbuf) const;
     bool allowed_by_incoming_filters(const struct buffer *pbuf) const;
 
@@ -248,6 +258,16 @@ protected:
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry) const;
     void _add_sys_comp_id(uint8_t sysid, uint8_t compid);
+
+        // Outgoing rate-limit configuration and state
+
+
+    // Returns true if allowed to send now (does NOT update last-sent)
+    bool _rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const;
+    // Record successful send time
+    void _rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms);
+    // Monotonic now in ms
+    static uint64_t _now_monotonic_ms();
 
     const std::string _type; ///< UART, UDP, TCP, Log
     std::string _name;       ///< Endpoint name from config file
@@ -275,6 +295,9 @@ protected:
 
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
+    std::unordered_map<uint32_t, uint32_t> _msg_and_rate_map;
+    // msg_id -> last sent timestamp (monotonic ms)
+    std::unordered_map<uint32_t, uint64_t> _throttled_msgs_last_send;
 
 private:
     std::vector<uint32_t> _allowed_outgoing_msg_ids;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -258,14 +258,10 @@ protected:
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry) const;
     void _add_sys_comp_id(uint8_t sysid, uint8_t compid);
-
-        // Outgoing rate-limit configuration and state
-
-
-    // Returns true if allowed to send now (does NOT update last-sent)
+    // Returns true if allowed to send now (does NOT update "last-sent" msg information)
     bool _rate_limit_allows(uint32_t msg_id, uint64_t now_ms) const;
-    // Record successful send time
-    void _rate_limit_mark_sent(uint32_t msg_id, uint64_t now_ms);
+    // Record successful msg send time
+    void _rate_limit_record_msg_sent(uint32_t msg_id, uint64_t now_ms);
     // Monotonic now in ms
     static uint64_t _now_monotonic_ms();
 
@@ -296,7 +292,6 @@ protected:
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
     std::unordered_map<uint32_t, uint32_t> _msg_and_rate_map;
-    // msg_id -> last sent timestamp (monotonic ms)
     std::unordered_map<uint32_t, uint64_t> _throttled_msgs_last_send;
 
 private:


### PR DESCRIPTION
Added the functionality to limit rates of specific messages being sent from router to the Endpoints. This feature is especially useful in setups that require high MAVLink bandwidth locally (for example, between companion computer applications and the flight controller), while needing to reduce the outgoing MAVLink rate to remote or bandwidth-constrained endpoints (e.g., radio links or cloud telemetry)..

Filters added:
```
RateLimitMsgIdOut
RateLimitPeriodOut

```
RateLimitMsgIdOut specifies which messages will be throttled
RateLimitPeriodOut specifies rates (in ms) for respective messages

Both filters must have the same number of entries to be applied, and their elements correspond positionally.

Example:
```
# QGC
[UdpEndpoint GCS]
Mode = Normal
Address = 10.223.0.250
Port = 14550
RateLimitMsgIdOut = 33,30
RateLimitPeriodOut = 1000,500
```
In this configuration:
- GLOBAL_POSITION_INT (msg ID 33) is limited to 1 Hz (sent every 1000 ms)
- ATTITUDE (msg ID 30) is limited to 2 Hz (sent every 500 ms)
