### PR TITLE
Add automatic reconnection support for UART endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,10 @@ Endpoint types (see [examples/config.sample](examples/config.sample) for the
 config file format):
 
   - UART: For telemetry radios or other serial links
-    * Configuration: UART device path/name and baudrate
-    * Behavior: Data is received and sent without waiting for incoming data first
+    * Configuration: UART device path/name, baudrate, and optional reconnection interval
+    * Behavior: Data is received and sent without waiting for incoming data first.
+      If the device is disconnected or unavailable at startup, automatic reconnection
+      will be attempted at the configured interval (default: 5 seconds)
   - UDP:
     * Configuration: Mode (client or server), IP address and port
     * Behavior in client mode: Endpoint is configured with a target IP and port
@@ -199,7 +201,8 @@ Defining endpoints:
     * A TCP client disconnects from the TCP server port
     * MAVLink Router is terminated
     * (This means that UART, UDP and TCP client endpoints are never destroyed
-      during runtime.)
+      during runtime. UART and TCP client endpoints will automatically attempt
+      to reconnect if disconnected.)
 
 ### Message Routing
 In general, each message received on one endpoint is delivered to all endpoints

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -116,6 +116,12 @@
 # Default: <false>
 #FlowControl = false
 
+# Enable automatic reconnect after the configured timeout in seconds. Set to 0
+# to disable reconnection. When a UART device is disconnected or unavailable
+# at startup, mavlink-router will attempt to reconnect at this interval.
+# Default: 5 seconds
+#RetryTimeout = 5
+
 # Only allow specified MAVLink message IDs to be sent via this endpoint. An
 # empty list allows all message IDs.
 # Format: Comma separated list of integers
@@ -199,6 +205,7 @@
 [UartEndpoint alpha]
 Device = /dev/ttyS0
 Baud = 52000
+RetryTimeout = 5
 
 
 ##

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -296,6 +296,7 @@ int Mainloop::loop()
                     request_exit(EXIT_FAILURE);
                 } else {
                     log_debug("Non-critical fd %i, error is okay.", p->fd);
+                    p->handle_error();
                 }
             }
         }

--- a/src/pollable.h
+++ b/src/pollable.h
@@ -39,4 +39,10 @@ public:
      * router exit.
      */
     virtual bool is_critical() { return true; };
+
+    /**
+     * Handle EPOLLERR events. Called when epoll reports an error
+     * on this fd. Can be used to trigger reconnection logic.
+     */
+    virtual void handle_error() { };
 };


### PR DESCRIPTION
Basically re-using the logic for the TCP endpoints to allow for reconnection and handling of UART endpoint disconnections