### PR TITLE
feat: add interface name binding for UDP server endpoints

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -217,8 +217,18 @@ Baud = 52000
 # Binding or target IP address (depending on mode).
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Binding to `0.0.0.0` or `[::]` will listen on all interfaces.
-# Mandatory, no default value
+# Either Address or Interface must be specified (see Interface below).
+# Default: no default value
 #Address = 
+
+# Network interface name to bind to (e.g. eth0, eth0.10, wlan0).
+# Only used in <server> mode. When set, the IPv4 address of the given
+# interface is resolved at startup and used as the bind address, instead
+# of the Address field. This allows the configuration to remain stable
+# even when the interface's IP address changes (e.g. DHCP renewal).
+# Either Address or Interface must be specified.
+# Default: Empty (disabled, use Address instead)
+#Interface = 
 
 # UDP port to be used with the configured address.
 # Mandatory in <server> mode, no default value
@@ -235,6 +245,18 @@ Baud = 52000
 Mode = Server
 Address = 0.0.0.0
 Port = 10000
+
+# bind to the IP address of eth0 on port 10001
+[UdpEndpoint bravo-eth0]
+Mode = Server
+Interface = eth0
+Port = 10001
+
+# bind to the IP address of a VLAN interface on port 10002
+[UdpEndpoint bravo-vlan]
+Mode = Server
+Interface = eth0.10
+Port = 10002
 
 # send to 127.0.0.1:11000
 [UdpEndpoint charlie]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Build and run mavlink-router unit tests.
+#
+# Usage:
+#   ./run_tests.sh              # full clean build + test
+#   ./run_tests.sh --no-clean   # incremental build + test
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${PROJECT_ROOT}/builddir-test"
+CLEAN=true
+
+for arg in "$@"; do
+    case "$arg" in
+        --no-clean) CLEAN=false ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+# ── Dependencies check ───────────────────────────────────────────────
+for cmd in meson ninja pkg-config; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: '$cmd' is required but not found in PATH." >&2
+        exit 1
+    fi
+done
+
+# ── Configure ────────────────────────────────────────────────────────
+if [ "$CLEAN" = true ] && [ -d "$BUILD_DIR" ]; then
+    echo "==> Removing previous build directory..."
+    rm -rf "$BUILD_DIR"
+fi
+
+if [ ! -d "$BUILD_DIR" ]; then
+    echo "==> Configuring project (build type: debug)..."
+    meson setup "$BUILD_DIR" "$PROJECT_ROOT" \
+        --buildtype=debug \
+        -Dsystemdsystemunitdir=/tmp/mavlink-router-test-units
+else
+    echo "==> Reconfiguring existing build directory..."
+    meson setup --reconfigure "$BUILD_DIR" "$PROJECT_ROOT"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────
+echo "==> Building..."
+meson compile -C "$BUILD_DIR"
+
+# ── Run tests ────────────────────────────────────────────────────────
+echo "==> Running unit tests..."
+meson test -C "$BUILD_DIR" --print-errorlogs --verbose
+
+echo ""
+echo "==> All tests passed."

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -78,7 +78,8 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
 
 const char *UdpEndpoint::section_pattern = "udpendpoint *";
 const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
-    {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
+    {"address",         false,   ConfFile::parse_stdstring,     OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
+    {"interface",       false,   ConfFile::parse_stdstring,     OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, interface)},
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
@@ -1076,10 +1077,61 @@ UdpEndpoint::~UdpEndpoint()
     }
 }
 
+bool UdpEndpoint::resolve_interface_address(const std::string &iface_name, std::string &ip_out)
+{
+    struct ifaddrs *ifaddr = nullptr;
+
+    if (getifaddrs(&ifaddr) == -1) {
+        log_error("Failed to enumerate network interfaces: %m");
+        return false;
+    }
+
+    bool found = false;
+    for (auto *ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr)
+            continue;
+        if (ifa->ifa_addr->sa_family != AF_INET)
+            continue;
+        if (iface_name != ifa->ifa_name)
+            continue;
+
+        char buf[INET_ADDRSTRLEN];
+        auto *sin = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
+        if (inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf))) {
+            ip_out = buf;
+            found = true;
+        }
+        break;
+    }
+
+    freeifaddrs(ifaddr);
+
+    if (!found) {
+        log_error("Interface '%s' not found or has no IPv4 address", iface_name.c_str());
+    }
+
+    return found;
+}
+
 bool UdpEndpoint::setup(UdpEndpointConfig conf)
 {
     if (!this->validate_config(conf)) {
         return false;
+    }
+
+    /*
+     * If an interface name is provided, resolve its IPv4 address
+     * and use it as the bind address. This takes priority over
+     * the 'address' field.
+     */
+    if (!conf.interface.empty()) {
+        std::string resolved_ip;
+        if (!resolve_interface_address(conf.interface, resolved_ip)) {
+            log_error("Could not resolve address for interface '%s'", conf.interface.c_str());
+            return false;
+        }
+        log_info("Interface '%s' resolved to %s", conf.interface.c_str(), resolved_ip.c_str());
+        conf.address = resolved_ip;
     }
 
     if (!this->open(conf.address.c_str(), conf.port, conf.mode)) {
@@ -1410,16 +1462,27 @@ int UdpEndpoint::parse_udp_mode(const char *val, size_t val_len, void *storage, 
 
 bool UdpEndpoint::validate_config(const UdpEndpointConfig &config)
 {
-    if (config.address.empty()) {
-        log_error("UdpEndpoint %s: IP address must be specified", config.name.c_str());
+    /*
+     * An endpoint must specify either an explicit IP address or
+     * a network interface name to resolve at bind time.
+     */
+    if (config.address.empty() && config.interface.empty()) {
+        log_error("UdpEndpoint %s: Either an IP address or an interface name must be specified",
+                  config.name.c_str());
         return false;
     }
 
-    if (!validate_ip(config.address)) {
-        log_error("UdpEndpoint %s: Invalid IP address %s",
-                  config.name.c_str(),
-                  config.address.c_str());
-        return false;
+    /*
+     * When an interface name is provided, the address will be resolved
+     * later in setup(), so skip IP validation here.
+     */
+    if (config.interface.empty()) {
+        if (!validate_ip(config.address)) {
+            log_error("UdpEndpoint %s: Invalid IP address %s",
+                      config.name.c_str(),
+                      config.address.c_str());
+            return false;
+        }
     }
 
     if (config.port == 0 || config.port == ULONG_MAX) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -76,6 +76,20 @@ struct UdpEndpointConfig {
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
     std::string group;
+
+    /**
+     * Optional network interface name (e.g. "eth0", "eth0.10", "wlan0").
+     *
+     * When set on a Server-mode endpoint, the bind address is resolved
+     * from this interface instead of using the 'address' field directly.
+     * This allows the configuration to remain stable even if the
+     * interface's IP address changes (e.g. DHCP renewal).
+     *
+     * Resolution priority:
+     *   1. If 'interface' is non-empty → resolve its IPv4 address at bind time.
+     *   2. Otherwise, fall back to 'address' (or "0.0.0.0" if also empty).
+     */
+    std::string interface;
 };
 
 struct TcpEndpointConfig {
@@ -336,6 +350,15 @@ public:
     static const char *section_pattern;
     static int parse_udp_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
     static bool validate_config(const UdpEndpointConfig &config);
+
+    /**
+     * Resolve the IPv4 address assigned to a network interface.
+     *
+     * @param iface_name  Network interface name (e.g. "eth0", "eth0.10", "wlan0").
+     * @param[out] ip_out Resolved IPv4 address in dotted-decimal notation.
+     * @return true on success, false if the interface is not found or has no IPv4 address.
+     */
+    static bool resolve_interface_address(const std::string &iface_name, std::string &ip_out);
 
 protected:
     bool open(const char *ip, unsigned long port,

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -586,6 +586,7 @@ TEST(UdpEndpointTest, ConfigValidateAddress)
 
     // build invalid IP address
     config.address = "";
+    config.interface = "";
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
 
     config.address = "[127.0.0.1]";
@@ -593,6 +594,46 @@ TEST(UdpEndpointTest, ConfigValidateAddress)
 
     config.address = "::1";
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+}
+
+TEST(UdpEndpointTest, ConfigValidateInterface)
+{
+    UdpEndpointConfig config;
+    config.port = 14550;
+    config.mode = UdpEndpointConfig::Mode::Server;
+
+    // Interface name provided without address: validation should pass
+    // (address will be resolved later in setup())
+    config.address = "";
+    config.interface = "eth0";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config))
+        << "with interface '" << config.interface << "' and no address";
+
+    // Both interface and address provided: validation should pass
+    config.address = "127.0.0.1";
+    config.interface = "eth0";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config))
+        << "with interface '" << config.interface << "' and address " << config.address;
+
+    // Neither address nor interface: validation should fail
+    config.address = "";
+    config.interface = "";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config))
+        << "with empty address and empty interface";
+}
+
+TEST(UdpEndpointTest, ResolveInterfaceAddress)
+{
+    std::string ip;
+
+    // Loopback interface is always available on Linux
+    EXPECT_TRUE(UdpEndpoint::resolve_interface_address("lo", ip));
+    EXPECT_EQ(ip, "127.0.0.1");
+
+    // Non-existent interface should fail
+    ip.clear();
+    EXPECT_FALSE(UdpEndpoint::resolve_interface_address("nonexistent_iface99", ip));
+    EXPECT_TRUE(ip.empty());
 }
 
 class UdpEndpointConfigPortTestFixture : public ::testing::TestWithParam<UdpEndpointConfig::Mode> {


### PR DESCRIPTION
## Add network interface name binding for UDP server endpoints

### Problem

When configuring a UDP server endpoint, an explicit IP address must be
provided. If the IP changes (DHCP renewal, network reconfiguration),
the configuration file must be manually updated and the service restarted.

### Solution

Introduce an `Interface` configuration option that accepts a network
interface name (e.g. `eth0`, `eth0.10`, `wlan0`). At startup, the IPv4
address assigned to the interface is resolved via `getifaddrs()` and
used as the bind address.

Either `Address` or `Interface` must be specified. When both are present,
`Interface` takes priority.

### Example configuration
```ini
[UdpEndpoint my-endpoint]
Mode = Server
Interface = eth0
Port = 10001
```

### Changes

- `UdpEndpointConfig`: new `std::string interface` field
- `UdpEndpoint::resolve_interface_address()`: static method, resolves
  interface name to IPv4 address using `getifaddrs()`
- `UdpEndpoint::setup()`: resolves interface before calling `open()`
- `UdpEndpoint::validate_config()`: accepts `interface` as an
  alternative to `address`
- `option_table`: new `Interface` entry, `Address` changed from
  mandatory to optional
- `endpoints_test.cpp`: two new tests (`ConfigValidateInterface`,
  `ResolveInterfaceAddress`)
- `config.sample`: updated documentation and added examples

### Testing

- All 30 unit tests pass (including 2 new tests)
- Manual validation: `Interface = enp2s0` correctly resolves and binds
  to `192.168.1.230:10001`

### Limitations

- IPv4 only (consistent with existing `open_ipv4()` behavior)
- Address is resolved once at startup; a service restart is needed if
  the IP changes while running