### PR TITLE
Install example config

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -196,9 +196,10 @@
 #Group = 
 
 ## Example
-[UartEndpoint alpha]
-Device = /dev/ttyS0
-Baud = 52000
+
+# [UartEndpoint alpha]
+# Device = /dev/ttyS0
+# Baud = 52000
 
 
 ##
@@ -231,16 +232,18 @@ Baud = 52000
 
 ## Examples
 # bind to 0.0.0.0:10000
-[UdpEndpoint bravo]
-Mode = Server
-Address = 0.0.0.0
-Port = 10000
+
+# [UdpEndpoint bravo]
+# Mode = Server
+# Address = 0.0.0.0
+# Port = 10000
 
 # send to 127.0.0.1:11000
-[UdpEndpoint charlie]
-Mode = Normal
-Address = 127.0.0.1
-Port = 11000
+
+# [UdpEndpoint charlie]
+# Mode = Normal
+# Address = 127.0.0.1
+# Port = 11000
 
 
 ##
@@ -269,6 +272,7 @@ Port = 11000
 
 ## Example
 # connect to 127.0.0.1:25760 (e.g. another mavlink-router)
-[TcpEndpoint delta]
-Address = 127.0.0.1
-Port = 25760
+
+# [TcpEndpoint delta]
+# Address = 127.0.0.1
+# Port = 25760

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -16,3 +16,9 @@ px4_offboard_mode = executable('px4-offboard-mode',
         link_with: libcommon_private,
         install: false,
 )
+
+install_data(
+        'config.sample',
+        install_dir: join_paths(get_option('sysconfdir'), 'mavlink-router'),
+        rename: 'main.conf',
+)

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project(
         default_options: [
                 'cpp_std=gnu++14',
                 'prefix=/usr',
+                'sysconfdir=/etc',
                 'warning_level=2',
                 'buildtype=debugoptimized',
         ],


### PR DESCRIPTION
* Comment out the example configs
* Install the example config

Closes #474 

# Tests Performed

1.

```
meson setup build
ninja -C build install
```


Observe `/etc/mavlink-router/main.conf` is created.

Then run mavlink-routerd and observe it not complain about missing config.

2.

Install in a local install tree.
```bash
DESTDIR=$(pwd)/install ninja -C build install
```

Verify the directory structure is created and does not require root.

```
ryan@friedmanr-ubuntu:~/Dev/mavlink-router$ tree install
install
├── etc
│   └── mavlink-router
│       └── main.conf
├── lib
│   └── systemd
│       └── system
│           └── mavlink-router.service
└── usr
    └── bin
        └── mavlink-routerd

7 directories, 3 files
```

