### PR TITLE
Fix missing cstdint in dedup.h

### DIFF
--- a/src/dedup.h
+++ b/src/dedup.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 class DedupImpl;


### PR DESCRIPTION
`src/dedup.h` seems to be missing `#include <cstdint>`

This can be most easily replicated by running the provided `examples/Dockerfile.alpine`. This yields
```
1.261 ninja: job failed: c++ -Isrc/mavlink-routerd.p -Isrc -I../src -I../modules/mavlink_c_library_v2/ardupilotmega -I. -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu++14 -O3 -Waddress-of-packed-member -Wno-inline -Wundef -Wformat=2 -Wlogical-op -Wsign-compare -Wformat-security -Wmissing-include-dirs -Wformat-nonliteral -Wpointer-arith -Winit-self -Wfloat-equal -Wredundant-decls -Wmissing-declarations -Wmissing-noreturn -Wshadow -Wendif-labels -Wstrict-aliasing=3 -Wwrite-strings -Wno-long-long -Wno-overlength-strings -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-result -Wchar-subscripts -Wtype-limits -Wuninitialized -include config.h -pthread -MD -MQ src/mavlink-routerd.p/dedup.cpp.o -MF src/mavlink-routerd.p/dedup.cpp.o.d -o src/mavlink-routerd.p/dedup.cpp.o -c ../src/dedup.cpp
1.262 In file included from ../src/dedup.cpp:17:
1.262 ../src/dedup.h:37:19: error: expected ')' before 'dedup_period_ms'
1.262    37 |     Dedup(uint32_t dedup_period_ms = 0);
1.262       |          ~        ^~~~~~~~~~~~~~~~
1.262       |                   )
1.262 ../src/dedup.h:40:27: error: 'uint32_t' has not been declared
1.262    40 |     void set_dedup_period(uint32_t dedup_period_ms);
1.262       |                           ^~~~~~~~
1.262 ../src/dedup.h:20:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
1.262    19 | #include <memory>
1.262   +++ |+#include <cstdint>
1.262    20 | 
1.262 ../src/dedup.h:42:37: error: 'uint8_t' does not name a type
1.262    42 |     PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
1.262       |                                     ^~~~~~~
1.262 ../src/dedup.h:42:37: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
1.262 ../src/dedup.h:42:54: error: 'uint32_t' has not been declared
1.262    42 |     PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
1.262       |                                                      ^~~~~~~~
1.262 ../src/dedup.h:42:54: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
1.262 ../src/dedup.h:45:5: error: 'uint32_t' does not name a type
1.262    45 |     uint32_t _dedup_period_ms; ///< how long
1.262       |     ^~~~~~~~
1.262 ../src/dedup.h:45:5: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
1.262 ../src/dedup.cpp:72:1: error: no declaration matches 'Dedup::Dedup(uint32_t)'
1.262    72 | Dedup::Dedup(uint32_t dedup_period_ms)
1.262       | ^~~~~
1.262 ../src/dedup.h:33:7: note: candidates are: 'Dedup::Dedup(const Dedup&)'
1.262    33 | class Dedup {
1.262       |       ^~~~~
1.262 ../src/dedup.h:33:7: note:                 'constexpr Dedup::Dedup()'
1.262 ../src/dedup.h:33:7: note: 'class Dedup' defined here
1.262 ../src/dedup.cpp:83:6: error: no declaration matches 'void Dedup::set_dedup_period(uint32_t)'
1.262    83 | void Dedup::set_dedup_period(uint32_t dedup_period_ms)
1.262       |      ^~~~~
1.262 ../src/dedup.h:40:10: note: candidate is: 'void Dedup::set_dedup_period(int)'
1.262    40 |     void set_dedup_period(uint32_t dedup_period_ms);
1.262       |          ^~~~~~~~~~~~~~~~
1.262 ../src/dedup.h:33:7: note: 'class Dedup' defined here
1.262    33 | class Dedup {
1.262       |       ^~~~~
1.262 ../src/dedup.cpp:88:21: error: no declaration matches 'Dedup::PacketStatus Dedup::check_packet(const uint8_t*, uint32_t)'
1.262    88 | Dedup::PacketStatus Dedup::check_packet(const uint8_t *buffer, uint32_t size)
1.262       |                     ^~~~~
1.262 ../src/dedup.h:42:18: note: candidate is: 'Dedup::PacketStatus Dedup::check_packet(const int*, int)'
1.262    42 |     PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
1.262       |                  ^~~~~~~~~~~~
1.262 ../src/dedup.h:33:7: note: 'class Dedup' defined here
1.262    33 | class Dedup {
1.262       |       ^~~~~
4.190 ninja: subcommand failed
```