### PR TITLE
Compatibility with newer Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ distros:
 
 Debian/Ubuntu:
 
-    $ sudo apt install git meson ninja-build pkg-config gcc g++ systemd
+    $ sudo apt install git meson ninja-build pkg-config gcc g++ systemd systemd-dev
 
 Fedora:
 
-    $ sudo dnf install git meson gcc g++ systemd
+    $ sudo dnf install git meson gcc g++ systemd systemd-dev
 
 Archlinux:
 
-    $ sudo pacman -S git meson gcc systemd
+    $ sudo pacman -S git meson gcc systemd systemd-dev
 
 Note that meson package must be version 0.55 or later. If your package manager
 does not have this version, a more recent version can be downloaded via pip:

--- a/src/dedup.h
+++ b/src/dedup.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 class DedupImpl;


### PR DESCRIPTION
In newer, leaner headers, the #include <memory> does not include c standard types. Adding the explicit include for the header fixes the build error. (os: Ubuntu 25.10)

Without the change we get the following build error:
```
/dedup.cpp.o.d -o src/mavlink-routerd.p/dedup.cpp.o -c ../src/dedup.cpp
In file included from ../src/dedup.cpp:17:
../src/dedup.h:37:19: error: expected ‘)’ before ‘dedup_period_ms’
   37 |     Dedup(uint32_t dedup_period_ms = 0);
      |          ~        ^~~~~~~~~~~~~~~~
      |                   )
../src/dedup.h:40:27: error: ‘uint32_t’ has not been declared
   40 |     void set_dedup_period(uint32_t dedup_period_ms);
      |                           ^~~~~~~~
../src/dedup.h:20:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   19 | #include <memory>
  +++ |+#include <cstdint>
   20 | 
../src/dedup.h:42:37: error: ‘uint8_t’ does not name a type
   42 |     PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
      |                                     ^~~~~~~
../src/dedup.h:42:37: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
../src/dedup.h:42:54: error: ‘uint32_t’ has not been declared
   42 |     PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
      |                                                      ^~~~~~~~
../src/dedup.h:42:54: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
../src/dedup.h:45:5: error: ‘uint32_t’ does not name a type
   45 |     uint32_t _dedup_period_ms; ///< how long
      |     ^~~~~~~~
../src/dedup.h:45:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
../src/dedup.cpp:72:1: error: no declaration matches ‘Dedup::Dedup(uint32_t)’
   72 | Dedup::Dedup(uint32_t dedup_period_ms)
      | ^~~~~
../src/dedup.h:33:7: note: candidates are: ‘Dedup::Dedup(const Dedup&)’
   33 | class Dedup {
      |       ^~~~~
../src/dedup.h:33:7: note:                 ‘constexpr Dedup::Dedup()’
../src/dedup.h:33:7: note: ‘class Dedup’ defined here
../src/dedup.cpp:83:6: error: no declaration matches ‘void Dedup::set_dedup_period(uint32_t)’
   83 | void Dedup::set_dedup_period(uint32_t dedup_period_ms)
      |      ^~~~~
../src/dedup.h:40:10: note: candidate is: ‘void Dedup::set_dedup_period(int)’
   40 |     void set_dedup_period(uint32_t dedup_period_ms);
      |          ^~~~~~~~~~~~~~~~
../src/dedup.h:33:7: note: ‘class Dedup’ defined here
   33 | class Dedup {
      |       ^~~~~
../src/dedup.cpp:88:21: error: no declaration matches ‘Dedup::PacketStatus Dedup::check_packet(const uint8_t*, uint32_t)’
   88 | Dedup::PacketStatus Dedup::check_packet(const uint8_t *buffer, uint32_t size)
      |                     ^~~~~
../src/dedup.h:42:18: note: candidate is: ‘Dedup::PacketStatus Dedup::check_packet(const int*, int)’
   42 |     PacketStatus check_packet(const uint8_t *buffer, uint32_t size);
      |                  ^~~~~~~~~~~~
../src/dedup.h:33:7: note: ‘class Dedup’ defined here
   33 | class Dedup {
      |       ^~~~~
[11/12] Compiling C++ object src/mavlink-routerd.p/mainloop.cpp.o
ninja: build stopped: subcommand failed.
```

Additionally the package `systemd-dev` is required on newer ubuntus (24.04 and 25.10)