### PR TITLE
Resolve hostnames when used as addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ config file format):
     * Configuration: UART device path/name and baudrate
     * Behavior: Data is received and sent without waiting for incoming data first
   - UDP:
-    * Configuration: Mode (client or server), IP address and port
+    * Configuration: Mode (client or server), IP address or hostname and port
     * Behavior in client mode: Endpoint is configured with a target IP and port
       combination. So MAVLink messages can be sent directly after startup, but
       will only be recevied after the first message was received by the remote
@@ -184,7 +184,7 @@ config file format):
       MAVLink messages are always sent to the IP and port from which the last
       incoming message was received.
   - TCP Client:
-    * Configuration: Target IP address and port, reconnection interval in case
+    * Configuration: Target IP address or hostname and port, reconnection interval in case
       of disconnection
     * Behavior: Data is received and sent right after the TCP session is
       established

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -217,6 +217,7 @@ Baud = 52000
 # Binding or target IP address (depending on mode).
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Binding to `0.0.0.0` or `[::]` will listen on all interfaces.
+# Can also use hostname.
 # Mandatory, no default value
 #Address = 
 
@@ -252,6 +253,7 @@ Port = 11000
 
 # Server IP address to connect to.
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
+# Can also use hostname.
 # Mandatory, no default value
 #Address = 
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -156,6 +156,117 @@ static bool validate_ip(const std::string &ip)
     return validate_ipv4(ip) || validate_ipv6(ip);
 }
 
+static bool validate_hostname(const std::string &hostname)
+{
+    if (hostname.empty() || hostname.size() > 253) {
+        return false;
+    }
+
+    size_t label_len = 0;
+
+    for (size_t i = 0; i < hostname.size(); i++) {
+        char c = hostname[i];
+
+        if (c == '.') {
+            /* dot terminates a label: must not be empty or start/end with hyphen */
+            if (label_len == 0) {
+                return false; /* empty label (leading dot or double dot) */
+            }
+            if (hostname[i - 1] == '-') {
+                return false; /* label ends with hyphen */
+            }
+            label_len = 0;
+        } else {
+            if (label_len == 0 && c == '-') {
+                return false; /* label starts with hyphen */
+            }
+            if (!isalnum((unsigned char)c) && c != '-') {
+                return false; /* invalid character */
+            }
+            label_len++;
+            if (label_len > 63) {
+                return false; /* label too long */
+            }
+        }
+    }
+
+    /* trailing dot is allowed (fully-qualified); otherwise last label must be non-empty */
+    if (label_len == 0 && hostname.back() != '.') {
+        return false;
+    }
+    /* last label must not end with a hyphen */
+    if (hostname.back() == '-') {
+        return false;
+    }
+
+    return true;
+}
+
+static bool validate_address(const std::string &addr)
+{
+    return validate_ip(addr) || validate_hostname(addr);
+}
+
+struct ResolvedAddr {
+    std::string ip;
+    bool is_ipv6;
+    bool valid;
+};
+
+static ResolvedAddr resolve_address(const std::string &address)
+{
+    /* Already a numeric IPv4 or bracketed IPv6 — use as-is */
+    if (validate_ipv4(address)) {
+        return {address, false, true};
+    }
+    if (validate_ipv6(address)) {
+        return {address, true, true};
+    }
+
+    /* Hostname — resolve via getaddrinfo.
+     * This handles plain DNS, mDNS (.local via nss-mdns/avahi),
+     * and Tailscale (*.ts.net) transparently. */
+    struct addrinfo hints;
+    struct addrinfo *result = nullptr;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_flags    = AI_ADDRCONFIG;
+
+    int rc = getaddrinfo(address.c_str(), nullptr, &hints, &result);
+    if (rc != 0) {
+        log_error("Could not resolve hostname '%s': %s", address.c_str(), gai_strerror(rc));
+        return {"", false, false};
+    }
+
+    char buf[INET6_ADDRSTRLEN + 2]; /* +2 for brackets around IPv6 */
+    ResolvedAddr resolved{"", false, false};
+
+    for (struct addrinfo *rp = result; rp != nullptr; rp = rp->ai_next) {
+        if (rp->ai_family == AF_INET) {
+            struct sockaddr_in *sin = (struct sockaddr_in *)rp->ai_addr;
+            inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf));
+            resolved = {buf, false, true};
+            break; /* prefer IPv4 over IPv6 */
+        }
+        if (rp->ai_family == AF_INET6 && !resolved.valid) {
+            struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)rp->ai_addr;
+            char tmp[INET6_ADDRSTRLEN];
+            inet_ntop(AF_INET6, &sin6->sin6_addr, tmp, sizeof(tmp));
+            /* wrap in brackets to match the rest of the code's convention */
+            snprintf(buf, sizeof(buf), "[%s]", tmp);
+            resolved = {buf, true, true};
+        }
+    }
+
+    freeaddrinfo(result);
+
+    if (!resolved.valid) {
+        log_error("Could not resolve hostname '%s' to a usable address", address.c_str());
+    }
+    return resolved;
+}
+
 static unsigned int ipv6_get_scope_id(const char *ip)
 {
     struct ifaddrs *addrs;
@@ -1082,6 +1193,19 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
         return false;
     }
 
+    /* Resolve hostname to numeric IP if needed */
+    if (!validate_ip(conf.address)) {
+        ResolvedAddr resolved = resolve_address(conf.address);
+        if (!resolved.valid) {
+            log_error("UdpEndpoint %s: Could not resolve address '%s'",
+                      conf.name.c_str(), conf.address.c_str());
+            return false;
+        }
+        log_info("UdpEndpoint %s: Resolved '%s' -> '%s'",
+                 conf.name.c_str(), conf.address.c_str(), resolved.ip.c_str());
+        conf.address = resolved.ip;
+    }
+
     if (!this->open(conf.address.c_str(), conf.port, conf.mode)) {
         log_error("Could not open %s:%ld", conf.address.c_str(), conf.port);
         return false;
@@ -1415,8 +1539,8 @@ bool UdpEndpoint::validate_config(const UdpEndpointConfig &config)
         return false;
     }
 
-    if (!validate_ip(config.address)) {
-        log_error("UdpEndpoint %s: Invalid IP address %s",
+    if (!validate_address(config.address)) {
+        log_error("UdpEndpoint %s: Invalid IP address or hostname '%s'",
                   config.name.c_str(),
                   config.address.c_str());
         return false;
@@ -1455,7 +1579,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
         return false;
     }
 
-    this->_ip = conf.address;
+    this->_hostname = conf.address;
     this->_port = conf.port;
     this->_retry_timeout = conf.retry_timeout;
 
@@ -1499,6 +1623,25 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
     this->_group_name = conf.group;
 
+    /* Resolve hostname to numeric IP if needed */
+    if (!validate_ip(conf.address)) {
+        ResolvedAddr resolved = resolve_address(conf.address);
+        if (!resolved.valid) {
+            log_warning("TcpEndpoint %s: Could not resolve '%s', re-trying every %d sec",
+                        conf.name.c_str(), conf.address.c_str(), this->_retry_timeout);
+            if (this->_retry_timeout > 0) {
+                _schedule_reconnect();
+                return true;
+            }
+            return false;
+        }
+        log_info("TcpEndpoint %s: Resolved '%s' -> '%s'",
+                 conf.name.c_str(), conf.address.c_str(), resolved.ip.c_str());
+        conf.address = resolved.ip;
+    }
+
+    this->_ip = conf.address;
+
     if (!this->open(conf.address, conf.port)) {
         log_warning("Could not open %s:%ld, re-trying every %d sec",
                     conf.address.c_str(),
@@ -1516,7 +1659,33 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
 bool TcpEndpoint::reopen()
 {
-    return this->open(_ip, _port);
+    std::string addr = _hostname;
+
+    /* Re-resolve the hostname on every reconnect attempt. This ensures that
+     * dynamic DNS entries (e.g. Tailscale *.ts.net or mDNS *.local) are
+     * refreshed rather than using a potentially stale cached IP. */
+    if (!validate_ip(_hostname)) {
+        ResolvedAddr resolved = resolve_address(_hostname);
+        if (resolved.valid) {
+            addr = resolved.ip;
+            _ip = addr;
+        } else {
+            /* Resolution failed — fall back to last known good IP if we have
+             * one, otherwise report failure and let the caller retry later. */
+            if (_ip.empty()) {
+                log_warning("TcpEndpoint %s: Could not resolve '%s' for reconnect",
+                            _name.c_str(), _hostname.c_str());
+                return false;
+            }
+            log_warning("TcpEndpoint %s: Could not resolve '%s', retrying with last known IP %s",
+                        _name.c_str(), _hostname.c_str(), _ip.c_str());
+            addr = _ip;
+        }
+    } else {
+        _ip = _hostname; /* it was always a bare IP, keep _ip consistent */
+    }
+
+    return this->open(addr, _port);
 }
 
 int TcpEndpoint::accept(int listener_fd)
@@ -1768,8 +1937,8 @@ bool TcpEndpoint::validate_config(const TcpEndpointConfig &config)
         return false;
     }
 
-    if (!validate_ip(config.address)) {
-        log_error("TcpEndpoint %s: Invalid IP address %s",
+    if (!validate_address(config.address)) {
+        log_error("TcpEndpoint %s: Invalid IP address or hostname '%s'",
                   config.name.c_str(),
                   config.address.c_str());
         return false;
@@ -1802,7 +1971,7 @@ void TcpEndpoint::_schedule_reconnect()
     if (t == nullptr) {
         log_warning("Could not create retry timeout for TCP endpoint %s:%lu\n"
                     "No attempts to reconnect will be made",
-                    _ip.c_str(),
+                    _hostname.c_str(),
                     _port);
     }
 }

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -394,6 +394,7 @@ private:
     std::string _ip{};
     unsigned long _port = 0;
     bool _valid = true;
+    std::string _hostname{};
 
     bool is_ipv6;
     int _retry_timeout = 0; // disable retry by default

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -577,21 +577,83 @@ TEST(UdpEndpointTest, ConfigValidateAddress)
     config.port = 14550;
     config.mode = UdpEndpointConfig::Mode::Client;
 
-    // build valid config
+    // valid IPv4 address
     config.address = "127.0.0.1";
     EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
 
+    // valid bracketed IPv6 address
     config.address = "[::1]";
     EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
 
-    // build invalid IP address
+    // empty address must be rejected
     config.address = "";
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
 
+    // IPv4 wrapped in brackets is not valid IPv6 and not a hostname
     config.address = "[127.0.0.1]";
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
 
+    // bare IPv6 without brackets must be rejected
     config.address = "::1";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+}
+
+TEST(UdpEndpointTest, ConfigValidateAddress_Hostname)
+{
+    UdpEndpointConfig config;
+    config.port = 14550;
+    config.mode = UdpEndpointConfig::Mode::Client;
+
+    // plain hostname
+    config.address = "localhost";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // mDNS .local name
+    config.address = "jetson.local";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // Tailscale VPN name
+    config.address = "jetson.tail8371dd.ts.net";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // multi-label DNS name
+    config.address = "support.ardupilot.org";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // single-label hostname with digits
+    config.address = "host42";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // hostname with hyphens inside labels
+    config.address = "my-drone-01.local";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // fully-qualified domain name with trailing dot
+    config.address = "drone.example.com.";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // label starting with hyphen must be rejected
+    config.address = "-invalid.local";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // label ending with hyphen must be rejected
+    config.address = "invalid-.local";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // double dot (empty label) must be rejected
+    config.address = "drone..local";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // leading dot (empty first label) must be rejected
+    config.address = ".drone.local";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // underscore is not a valid hostname character
+    config.address = "my_drone.local";
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // spaces are not valid
+    config.address = "my drone.local";
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with address " << config.address;
 }
 
@@ -668,21 +730,82 @@ TEST(TcpEndpointTest, ConfigValidateAddress)
     TcpEndpointConfig config;
     config.port = 14550;
 
-    // build valid config
+    // valid IPv4 address
     config.address = "127.0.0.1";
     EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
 
+    // valid bracketed IPv6 address
     config.address = "[::1]";
     EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
 
-    // build invalid IP address
+    // empty address must be rejected
     config.address = "";
     EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
 
+    // IPv4 wrapped in brackets is not valid IPv6 and not a hostname
     config.address = "[127.0.0.1]";
     EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
 
+    // bare IPv6 without brackets must be rejected
     config.address = "::1";
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+}
+
+TEST(TcpEndpointTest, ConfigValidateAddress_Hostname)
+{
+    TcpEndpointConfig config;
+    config.port = 14550;
+
+    // plain hostname
+    config.address = "localhost";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // mDNS .local name
+    config.address = "jetson.local";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // Tailscale VPN name
+    config.address = "jetson.tail8371dd.ts.net";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // multi-label DNS name
+    config.address = "support.ardupilot.org";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // single-label hostname with digits
+    config.address = "host42";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // hostname with hyphens inside labels
+    config.address = "my-drone-01.local";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // fully-qualified domain name with trailing dot
+    config.address = "drone.example.com.";
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // label starting with hyphen must be rejected
+    config.address = "-invalid.local";
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // label ending with hyphen must be rejected
+    config.address = "invalid-.local";
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // double dot (empty label) must be rejected
+    config.address = "drone..local";
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // leading dot (empty first label) must be rejected
+    config.address = ".drone.local";
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // underscore is not a valid hostname character
+    config.address = "my_drone.local";
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
+
+    // spaces are not valid
+    config.address = "my drone.local";
     EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with address " << config.address;
 }
 


### PR DESCRIPTION
# Purpose

Support resolving hostnames instead of just addresses, such as support.ardupilot.org.

# Tests Performed

* Used a local mdns address like `jetson.local`
* Used a tailscale VPN address like `jetson.tail8371dd.ts.net`
* Added some unit tests

# Disclosure

Coded with help from claude, validated with manual testing