### PR TITLE
FreeBSD 15 compat (libepoll-shim + UART/termios + IPv4 jails + example fixes)

### DIFF
--- a/examples/arm-authorizer.cpp
+++ b/examples/arm-authorizer.cpp
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
@@ -42,7 +43,7 @@
 static volatile bool g_should_exit;
 
 static int fd;
-static struct sockaddr_in sockaddr;
+static struct sockaddr_in srv_addr;
 
 static timespec auth_request_timeout;
 static timespec heartbeat_timeout;
@@ -81,7 +82,7 @@ static int msg_send(mavlink_message_t *msg)
     uint8_t data[MAVLINK_MAX_PACKET_LEN];
 
     uint16_t len = mavlink_msg_to_send_buffer(data, msg);
-    return sendto(fd, data, len, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    return sendto(fd, data, len, 0, (struct sockaddr *)&srv_addr, sizeof(srv_addr));
 }
 
 static void command_ack_send(mavlink_command_ack_t *ack)
@@ -283,8 +284,8 @@ static void loop()
         mavlink_message_t msg;
         mavlink_status_t status;
         uint8_t buf[MAVLINK_MAX_PACKET_LEN];
-        socklen_t addrlen = sizeof(sockaddr);
-        ssize_t n = recvfrom(fd, buf, sizeof(buf), 0, (struct sockaddr *)&sockaddr, &addrlen);
+        socklen_t addrlen = sizeof(srv_addr);
+        ssize_t n = recvfrom(fd, buf, sizeof(buf), 0, (struct sockaddr *)&srv_addr, &addrlen);
 
         if (n == -1) {
             if (errno == EINTR) {
@@ -356,12 +357,12 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    memset(&sockaddr, 0, sizeof(struct sockaddr_in));
-    sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(ip);
-    sockaddr.sin_port = htons(port);
+    memset(&srv_addr, 0, sizeof(struct sockaddr_in));
+    srv_addr.sin_family = AF_INET;
+    srv_addr.sin_addr.s_addr = inet_addr(ip);
+    srv_addr.sin_port = htons(port);
 
-    int ret = connect(fd, (struct sockaddr *)&sockaddr, sizeof(struct sockaddr_in));
+    int ret = connect(fd, (struct sockaddr *)&srv_addr, sizeof(struct sockaddr_in));
     if (ret) {
         fprintf(stderr, "Could not connect to socket (%m)\n");
         goto connect_error;

--- a/examples/heartbeat-print.cpp
+++ b/examples/heartbeat-print.cpp
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -60,8 +61,8 @@ static void handle_new_message(const mavlink_message_t *msg)
 
 int main(int argc, char *argv[])
 {
-    struct sockaddr_in sockaddr;
-    const socklen_t addrlen = sizeof(sockaddr);
+    struct sockaddr_in srv_addr;
+    const socklen_t addrlen = sizeof(srv_addr);
     int port = 14550;
     int fd;
 
@@ -86,12 +87,12 @@ int main(int argc, char *argv[])
     }
     printf("Connecting to: %s:%i\n", ip, port);
 
-    bzero(&sockaddr, addrlen);
-    sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(ip);
-    sockaddr.sin_port = htons(port);
+    bzero(&srv_addr, addrlen);
+    srv_addr.sin_family = AF_INET;
+    srv_addr.sin_addr.s_addr = inet_addr(ip);
+    srv_addr.sin_port = htons(port);
 
-    if (bind(fd, (struct sockaddr *)&sockaddr, addrlen) == -1) {
+    if (bind(fd, (struct sockaddr *)&srv_addr, addrlen) == -1) {
         fprintf(stderr, "Could not bind to %s:%d (%m)", ip, port);
         free(ip);
         return 1;

--- a/examples/px4-offboard-mode.cpp
+++ b/examples/px4-offboard-mode.cpp
@@ -43,6 +43,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/timerfd.h>
 #include <time.h>
@@ -65,7 +66,7 @@
 static volatile bool g_should_exit;
 
 static int tcp_fd = -1;
-static struct sockaddr_in sockaddr;
+static struct sockaddr_in srv_addr;
 
 static int timeout_fd = -1;
 
@@ -153,7 +154,7 @@ static int msg_send(mavlink_message_t *msg)
     uint8_t data[MAVLINK_MAX_PACKET_LEN];
 
     uint16_t len = mavlink_msg_to_send_buffer(data, msg);
-    int r = sendto(tcp_fd, data, len, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    int r = sendto(tcp_fd, data, len, 0, (struct sockaddr *)&srv_addr, sizeof(srv_addr));
     if (r < 0) {
         fprintf(stderr, "Could not send to %d: r=%d (%m)\n", tcp_fd, r);
     }
@@ -524,8 +525,8 @@ static int tcp_fd_poll_handle(const struct pollfd *d)
         mavlink_message_t msg;
         mavlink_status_t status;
         uint8_t buf[MAVLINK_MAX_PACKET_LEN];
-        socklen_t addrlen = sizeof(sockaddr);
-        ssize_t n = recvfrom(tcp_fd, buf, sizeof(buf), 0, (struct sockaddr *)&sockaddr, &addrlen);
+        socklen_t addrlen = sizeof(srv_addr);
+        ssize_t n = recvfrom(tcp_fd, buf, sizeof(buf), 0, (struct sockaddr *)&srv_addr, &addrlen);
 
         if (n == -1) {
             if (errno == EINTR) {
@@ -602,13 +603,13 @@ static int setup_connection(const char *ip, int port)
         return -1;
     }
 
-    sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(ip);
-    sockaddr.sin_port = htons(port);
+    srv_addr.sin_family = AF_INET;
+    srv_addr.sin_addr.s_addr = inet_addr(ip);
+    srv_addr.sin_port = htons(port);
 
     printf("Connecting to TCP: %s:%i\n", ip, port);
 
-    if (connect(tcp_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
+    if (connect(tcp_fd, (struct sockaddr *)&srv_addr, sizeof(srv_addr)) != 0) {
         fprintf(stderr, "Could not connect to socket (%m)\n");
         return -1;
     }

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,12 @@ dep_math = cxx.find_library('m')
 dep_rt = cxx.find_library('rt')
 dep_thread = dependency('threads')
 
+if host_machine.system() != 'linux'
+    dep_epoll_shim = dependency('epoll-shim', required: true)
+else
+    dep_epoll_shim = dependency('', required: false)
+endif
+
 # Optional dependencies
 systemd_system_unit_dir = get_option('systemdsystemunitdir')
 if systemd_system_unit_dir == 'auto'

--- a/src/comm.h
+++ b/src/comm.h
@@ -18,7 +18,11 @@
 #pragma once
 
 #include <arpa/inet.h>
+#ifdef __linux__
 #include <asm/termbits.h>
+#else
+#include <termios.h>
+#endif
 #include <errno.h>
 #include <inttypes.h>
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -66,5 +66,4 @@ template <typename type> bool vector_contains(std::vector<type> vect, type elem)
             (char *)memcpy(__out, __in, __len);      \
         }))
 
-#    include <asm/ioctls.h>
 #endif

--- a/src/common/xtermios.cpp
+++ b/src/common/xtermios.cpp
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /*
  * This file is part of the MAVLink Router project
  *
@@ -63,3 +64,34 @@ int reset_uart(int fd)
 
     return 0;
 }
+
+#else
+/* BSD-compat reset_uart. Linux's NCCS=32 vs BSD's NCCS=20 means
+ * the verbatim Linux body would static_assert; this branch uses
+ * cfmakeraw plus a few flag tweaks that produce a known-good raw
+ * mode equivalent to the Linux "stty-sane" defaults for USB CDC
+ * ACM. Real RS-232 / UART at non-standard baud rates may need a
+ * fuller port using cfsetspeed + per-flag handling. */
+
+#include <termios.h>
+#include <unistd.h>
+#include "log.h"
+#include "xtermios.h"
+
+int reset_uart(int fd)
+{
+    struct termios tc;
+    if (tcgetattr(fd, &tc) != 0) {
+        return -1;
+    }
+    cfmakeraw(&tc);
+    tc.c_cflag |= (CLOCAL | CREAD);
+    tc.c_cflag &= ~(CRTSCTS);
+    tc.c_cc[VMIN] = 0;
+    tc.c_cc[VTIME] = 0;
+    if (tcsetattr(fd, TCSANOW, &tc) != 0) {
+        return -1;
+    }
+    return 0;
+}
+#endif /* __linux__ */

--- a/src/common/xtermios.h
+++ b/src/common/xtermios.h
@@ -22,3 +22,34 @@
  * same time
  */
 int reset_uart(int fd);
+
+/*
+ * FreeBSD compat shim. Linux's <asm/termbits.h> defines
+ * struct termios2, TCGETS2, TCSETS2, BOTHER, CBAUD. FreeBSD has
+ * plain POSIX struct termios with c_ispeed / c_ospeed. Mapping
+ * termios2 to termios + TCGETS2/TCSETS2 to TIOCGETA/TIOCSETA lets
+ * endpoint.cpp's set_speed, set_flow_control and open paths
+ * compile unchanged. BOTHER and CBAUD become no-ops because
+ * FreeBSD does not pack baud rate into c_cflag.
+ *
+ * termios2 is a #define rather than a typedef so that
+ * "struct termios2 tc" declarations expand to "struct termios tc"
+ * (C++ does not allow the "struct" keyword with a typedef alias).
+ */
+#ifndef __linux__
+#include <termios.h>
+#include <sys/ioctl.h>
+#define termios2 termios
+#ifndef TCGETS2
+#define TCGETS2 TIOCGETA
+#endif
+#ifndef TCSETS2
+#define TCSETS2 TIOCSETA
+#endif
+#ifndef BOTHER
+#define BOTHER 0
+#endif
+#ifndef CBAUD
+#define CBAUD 0
+#endif
+#endif /* __linux__ */

--- a/src/common/xtermios.h
+++ b/src/common/xtermios.h
@@ -53,3 +53,43 @@ int reset_uart(int fd);
 #define CBAUD 0
 #endif
 #endif /* __linux__ */
+
+/* Linux-only termios output flags used by endpoint.cpp; map to
+ * 0 so bitwise masks become no-ops on POSIX. */
+#ifndef __linux__
+#ifndef OLCUC
+#define OLCUC 0
+#endif
+#ifndef OFILL
+#define OFILL 0
+#endif
+#ifndef OFDEL
+#define OFDEL 0
+#endif
+#ifndef ONLRET
+#define ONLRET 0
+#endif
+#ifndef IUCLC
+#define IUCLC 0
+#endif
+#ifndef IUTF8
+#define IUTF8 0
+#endif
+#ifndef XCASE
+#define XCASE 0
+#endif
+#ifndef ECHOPRT
+#define ECHOPRT 0
+#endif
+#ifndef ECHOCTL
+#define ECHOCTL 0
+#endif
+#ifndef ECHOKE
+#define ECHOKE 0
+#endif
+/* Linux defines IPV6_ADD_MEMBERSHIP in <netinet/in.h>; POSIX /
+ * BSD only define IPV6_JOIN_GROUP. They identify the same option. */
+#ifndef IPV6_ADD_MEMBERSHIP
+#define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
+#endif
+#endif /* __linux__ */

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -49,6 +49,18 @@
 
 #include "mainloop.h"
 
+/* Drop libepoll-shim's `#define close(...) epoll_shim_close(...)`
+ * macro after all system includes are pulled in. Without this the
+ * macro would substitute every `close()` call site, including
+ * member functions of TcpEndpoint, breaking compilation. epoll
+ * fds in this code base are only opened/closed in mainloop.cpp,
+ * where the macro remains active. */
+#ifdef __FreeBSD__
+#undef close
+#endif
+
+
+
 #define RX_BUF_MAX_SIZE (MAVLINK_MAX_PACKET_LEN * 4)
 #define TX_BUF_MAX_SIZE (8U * 1024U)
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -27,7 +27,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
+#ifdef __linux__
 #include <linux/serial.h>
+#endif
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
@@ -823,7 +825,7 @@ int UartEndpoint::set_speed(speed_t baudrate)
 
     log_info("UART [%d]%s: speed = %u", fd, _name.c_str(), baudrate);
 
-    if (ioctl(fd, TCFLSH, TCIOFLUSH) == -1) {
+    if (tcflush(fd, TCIOFLUSH) == -1) {
         log_error("UART [%d]%s: Could not flush terminal (%m)", fd, _name.c_str());
         return -1;
     }
@@ -916,6 +918,7 @@ bool UartEndpoint::open(const char *path)
     // chip sets if their driver does not support this
     // configuration request
 
+#ifdef __linux__
     {
         struct serial_struct serial_ctl;
 
@@ -936,7 +939,8 @@ bool UartEndpoint::open(const char *path)
     }
 
 set_latency_failed:
-    if (ioctl(fd, TCFLSH, TCIOFLUSH) == -1) {
+#endif /* __linux__ */
+    if (tcflush(fd, TCIOFLUSH) == -1) {
         log_error("Could not flush terminal on %s (%m)", path);
         goto fail;
     }

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <netinet/in.h>
 #include <common/conf_file.h>
 #include <common/mavlink.h>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,13 @@ static void help(FILE *fp)
         "  -s --sniffer-sysid           Sysid that all messages are sent to.\n"
         "  -y --syslog                  Use syslog output instead of stderr\n"
         "  -h --help                    Print this message\n",
-        program_invocation_short_name);
+        (
+#ifdef __linux__
+        program_invocation_short_name
+#else
+        getprogname()
+#endif
+        ));
 }
 
 static uint32_t find_next_udp_port(const std::string &ip, const Configuration &config)

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -20,6 +20,9 @@
 #include <assert.h>
 #include <signal.h>
 #include <sys/epoll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
 #include <sys/timerfd.h>
 #include <unistd.h>
 

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -472,10 +472,21 @@ void Mainloop::clear_endpoints()
 int Mainloop::tcp_open(unsigned long tcp_port)
 {
     int fd;
+#ifdef __FreeBSD__
+    /* IPv6 sockets are not allowed in non-vnet jails without an
+     * explicit ip6.addr; fall back to IPv4 on FreeBSD. The TCP
+     * debug port targets MAVProxy / Wireshark on the local
+     * network where IPv4 is sufficient. */
+    struct sockaddr_in sockaddr = {};
+    int val = 1;
+
+    fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+#else
     struct sockaddr_in6 sockaddr = {};
     int val = 1;
 
     fd = socket(AF_INET6, SOCK_STREAM | SOCK_NONBLOCK, 0);
+#endif
     if (fd == -1) {
         log_error("TCP Server: Could not create tcp socket (%m)");
         return -1;
@@ -483,9 +494,15 @@ int Mainloop::tcp_open(unsigned long tcp_port)
 
     setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 
+#ifdef __FreeBSD__
+    sockaddr.sin_family = AF_INET;
+    sockaddr.sin_port = htons(tcp_port);
+    sockaddr.sin_addr.s_addr = INADDR_ANY;
+#else
     sockaddr.sin6_family = AF_INET6;
     sockaddr.sin6_port = htons(tcp_port);
     sockaddr.sin6_addr = in6addr_any;
+#endif
 
     if (bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) < 0) {
         log_error("TCP Server: Could not bind to tcp socket (%m)");

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,6 +21,7 @@ exe_mavlink_router = executable('mavlink-routerd',
                 dep_math,
                 dep_rt,
                 dep_thread,
+                dep_epoll_shim,
         ],
         link_with: libcommon_private,
         install: true,
@@ -46,6 +47,7 @@ if dep_gtest.found()
           dependencies : [
             dep_gtest,
             dep_rt,
+            dep_epoll_shim,
           ],
           link_with: libcommon_private,
           install: false,
@@ -71,6 +73,7 @@ if dep_gtest.found()
           dependencies : [
             dep_gtest,
             dep_rt,
+            dep_epoll_shim,
           ],
           link_with: libcommon_private,
           install: false,


### PR DESCRIPTION
# FreeBSD 15 compat (libepoll-shim + UART/termios + IPv4 jails + example fixes)

This series adds FreeBSD 15.0-RELEASE arm64 support to
mavlink-router by gating Linux-only headers + APIs on
`#ifdef __linux__` and providing POSIX-equivalent fallbacks
elsewhere. Verified end-to-end on the platform in question;
Linux builds are unchanged.

## Summary of changes

| # | Subject | What changes | Why |
|---|---|---|---|
| 1 | Gate Linux UAPI headers + termios on `__linux__` | `<asm/ioctls.h>`, `<asm/termbits.h>`, `<linux/serial.h>`, the `TIOCGSERIAL`/`TIOCSSERIAL` block, and the `set_latency_failed:` label inside `endpoint.cpp` are wrapped in `#ifdef __linux__`. POSIX `tcflush()` replaces the Linux-only `ioctl(fd, TCFLSH, ...)`. `xtermios.h` gains a non-Linux shim that maps `termios2 → struct termios` (via `#define`, so `struct termios2 tc` declarations stay valid) and stubs out `TCGETS2 / TCSETS2 / BOTHER / CBAUD`. | These headers don't exist on non-Linux. The label-and-block guard pattern keeps the success-path `tcflush()` reachable in both branches. |
| 2 | Route epoll through libepoll-shim, neutralise `close()` macro, `getprogname()` | Top-level `meson.build` declares `dep_epoll_shim = dependency('epoll-shim')` on non-Linux and threads it into the executables. `xtermios.h` zero-stubs the Linux-only termios flags `endpoint.cpp` masks (OLCUC/OFILL/OFDEL/...) and aliases `IPV6_ADD_MEMBERSHIP` → `IPV6_JOIN_GROUP`. `#undef close` after `#include "mainloop.h"` in `endpoint.cpp` so `libepoll-shim`'s `#define close(...) epoll_shim_close(__VA_ARGS__)` macro doesn't eat C++ class member names. `main.cpp` swaps glibc's `program_invocation_short_name` for POSIX `getprogname()` under `#ifndef __linux__`. `mainloop.cpp` gets explicit `<sys/socket.h>`/`<netinet/in.h>`/`<unistd.h>` includes (Linux pulls them transitively via `asm/termbits.h`; FreeBSD does not). | FreeBSD has no `<sys/epoll.h>`; `libepoll-shim` provides a kqueue-backed equivalent. The `#undef close` is a workaround for the macro design rather than a rename of the member function — see "Open question" below. |
| 3 | AF_INET fallback for `Mainloop::tcp_open` | On `__FreeBSD__`, the struct type, `socket()` family, and field writes drop to IPv4. | Non-vnet FreeBSD jails without an explicit `ip6.addr` deny IPv6 socket creation entirely (`EPROTONOSUPPORT`). The TCP debug port targets local MAVProxy / Wireshark, IPv4 is sufficient. |
| 4 | BSD-compat `reset_uart` in `xtermios.cpp` | Linux body wrapped in `#ifdef __linux__`; non-Linux branch uses `cfmakeraw` + a small flag tweak set (CLOCAL\|CREAD, no CRTSCTS, VMIN=0/VTIME=0) producing a known-good raw mode for USB CDC ACM. | The Linux body's hand-built 32-byte `c_cc` defaults trip FreeBSD's `NCCS=20` static_assert. CDC ACM's host-side termios state is largely advisory anyway; for real RS-232 / UART at non-standard baud rates a fuller cfsetspeed-based port is the natural follow-up. |
| 5 | examples: fix FreeBSD compile (sockaddr shadow + missing `<netinet/in.h>`) | Renames the local `static struct sockaddr_in sockaddr;` variable to `srv_addr` in `arm-authorizer.cpp`, `heartbeat-print.cpp`, `px4-offboard-mode.cpp` (the local name was shadowing the global `struct sockaddr` typedef; FreeBSD libc++ + recent Linux clang reject it). Adds explicit `<netinet/in.h>` next to `<sys/socket.h>` (Linux pulls it transitively, POSIX does not). | Behaviour unchanged on Linux; lets the examples build out-of-the-box on FreeBSD. |

## Verification

* Tested on FreeBSD 15.0-RELEASE arm64 (Parallels VM hosting a
  jail) with `meson 1.10.2`, `ninja 1.13.2`, clang in the
  base system.
* `meson setup build --buildtype=release` + `ninja -C build`
  completes with **0 warnings, 0 errors** for both the library
  and the three examples.
* `build/src/mavlink-routerd --version` reports
  `mavlink-router version 3`.
* The same series, applied to a fresh upstream `master` clone
  in the FreeBSD jail used by the BUREVII project, has been
  serving live MAVLink traffic between QGC and an Ardal MCU
  via UART since the patch set was put together.

## Tradeoffs / open questions

These are conscious choices on this submission; happy to
iterate on any in review:

* **`#undef close` workaround vs. member rename.**
  `Tcp/UdpEndpoint::close()` member names collide with
  `libepoll-shim`'s `close(...)` macro. Renaming
  `Tcp/UdpEndpoint::close()` → `close_fd()` would be the
  language-level fix; this series keeps the change footprint
  minimal and uses the file-local `#undef` instead. Happy to
  switch if you'd prefer the rename.
* **`#ifdef __linux__` gates vs. `#ifndef __FreeBSD__` /
  feature detection.** Most guards target Linux UAPI headers
  that, by definition, only exist on Linux, so `__linux__` is
  the most semantically correct gate. NetBSD / OpenBSD /
  DragonFly support would need additional gates or feature
  detection; this series targets FreeBSD specifically. Happy
  to broaden if maintainers prefer.
* **`xtermios.cpp` BSD branch.** Uses `cfmakeraw` rather than
  the Linux body's verbatim "stty-sane" defaults. Equivalent
  for USB CDC ACM (the platform's primary physical link); for
  real RS-232 at non-standard baud rates a fuller port using
  `cfsetspeed` + per-flag handling is the natural follow-up.

## Acknowledgements

The series formalises a patch set that has been carried
out-of-tree by the [BUREVII CPE OS](https://github.com/Inkeer/FreeBSD)
project since April 2026; the underlying re-applied patch
scripts in
`scripts/freebsd-mavlink-router/` over there have served the
project's lab VM and field deployments. Submitting in-tree so
future FreeBSD users don't have to reinvent the wheel.
