### PR TITLE
Delay log stop after disarm to log post-disarm data in while-armed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or in order to install to another root directory:
 There are two ways to configure mavlink-router: Configuration file(s) and
 command line parameters. You can use just config files or just CLI options or
 even both at the same time. The CLI options will be merged with the settings
-from the config file in the latter case.  
+from the config file in the latter case.
 The configuration file gives more fine-grained control over the endpoints while
 the CLI options enable a quick configuration. When using the systemd unit
 added by the install step, it's recommended to use the configuration file
@@ -169,7 +169,7 @@ config file format):
     * Behavior in client mode: Endpoint is configured with a target IP and port
       combination. So MAVLink messages can be sent directly after startup, but
       will only be recevied after the first message was received by the remote
-      side, it doesn't know our IP and port otherwise.  
+      side, it doesn't know our IP and port otherwise.
       When using any non-unicast IP address, e.g. an IPv4 broadcast or IPv6
       local network multicast (ff02::1), messages will be "broadcasted" until
       somebody sends data back. From then on, UDP packets will only be sent to
@@ -180,7 +180,7 @@ config file format):
       IP address. This is essentially the opposite of client mode. Messages can
       be received directly after startup, but we can only send messages out
       after the first received message, because we don't know the remote IP and
-      port otherwise.  
+      port otherwise.
       MAVLink messages are always sent to the IP and port from which the last
       incoming message was received.
   - TCP Client:
@@ -205,7 +205,7 @@ Defining endpoints:
 In general, each message received on one endpoint is delivered to all endpoints
 in which that target system/component has been seen. If it's a broadcast
 message, it's delivered to all endpoints. A message is never sent back to the
-same endpoint it came from.  
+same endpoint it came from.
 Details on broadcast rules can be found in the official
 [MAVLink documentation](http://mavlink.io/en/guide/routing.html).
 
@@ -222,7 +222,7 @@ Routing rules:
     3. Accept the message, if it's targeted to any of the systems in the list
       of connected systems on this endpoint. Broadcast rules apply when
       checking if the targeted is reachable via this endpoint. Messages without
-      target address count as broadcast.  
+      target address count as broadcast.
       If the list of connected systems is empty, only system-ID broadcast
       messages will be sent, but no component-ID broadcasts since the targeted
       system isn't known to be reachable via this endpoint.
@@ -240,8 +240,8 @@ Message filters:
   - And a message filter can either be a block- or allow-list:
     - **Block**: Discard all messages matching the respective identifier (and allow all other ones)
     - **Allow**: Allow all messages matching the respective identifier (and discard all other ones)
-    - Note that while using "Allow" and "Block" filters on the same identifier 
-    within an endpoint doesn't make sense, using them on different identifiers 
+    - Note that while using "Allow" and "Block" filters on the same identifier
+    within an endpoint doesn't make sense, using them on different identifiers
     can be useful (for example, allowing only specific outgoing SysID, and
     blocking this system from sending some unwanted message IDs).
   - So a filter might be named `AllowMsgIdOut` to only allow messages with the listed message ID to be transmitted on that endpoint. See the example config [examples/config.sample](examples/config.sample) for the exact name of each filter parameter.
@@ -252,7 +252,7 @@ Message de-duplication:
     already received the last `DeduplicationPeriod` milliseconds ago. If it's
     already known, the message will be dropped as it was never received and the
     timeout counter for that message will be reset. Messages are identified via
-    their `std::hash` value of the full MAVLink message including it's header.  
+    their `std::hash` value of the full MAVLink message including it's header.
     As long as no message with exactly the same header sequence number and
     content is received during the configured period, everything is fine. The
     most critical message is the heartbeat since it mostly contains static
@@ -262,7 +262,7 @@ Message de-duplication:
 Endpoint groups:
 
   - Multiple endpoints can be configured to be in the same endpoin group.
-    Endpoints in the same group will share the same list of connected systems.  
+    Endpoints in the same group will share the same list of connected systems.
     When using two (or more) **parallel data links**, e.g. LTE and telemetry
     radio, the endpoint **must** be grouped on both sides. Otherwise one link
     will not be used any more because of routing rule 1.
@@ -292,12 +292,16 @@ Logs are collected on `.bin` (for Ardupilot) or `.ulg` (for PX4) files in the
 specified directory. Note that they are named `XXXXX-date-time`, where `XXXXX`
 is an increasing number.
 
+When `LogMode=while-armed` is used, `LogStopDelay` can be set to keep collecting
+post-disarm logger data before stopping the flight stack log. It defaults to `0`,
+which preserves the existing behavior of stopping immediately on disarm.
+
 #### Telemetry Logging
 
-Similar to flight stack logging its also possible to write the raw telemetry 
-data as `.tlog` file using the `LogTelemetry` key in the `General` section 
+Similar to flight stack logging its also possible to write the raw telemetry
+data as `.tlog` file using the `LogTelemetry` key in the `General` section
 (or use argument `-T`). Note that this only works if a path using flight
-stack logging is set! 
+stack logging is set!
 All options from flightstack logging apply also here.
 
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or in order to install to another root directory:
 There are two ways to configure mavlink-router: Configuration file(s) and
 command line parameters. You can use just config files or just CLI options or
 even both at the same time. The CLI options will be merged with the settings
-from the config file in the latter case.
+from the config file in the latter case.  
 The configuration file gives more fine-grained control over the endpoints while
 the CLI options enable a quick configuration. When using the systemd unit
 added by the install step, it's recommended to use the configuration file
@@ -169,7 +169,7 @@ config file format):
     * Behavior in client mode: Endpoint is configured with a target IP and port
       combination. So MAVLink messages can be sent directly after startup, but
       will only be recevied after the first message was received by the remote
-      side, it doesn't know our IP and port otherwise.
+      side, it doesn't know our IP and port otherwise.  
       When using any non-unicast IP address, e.g. an IPv4 broadcast or IPv6
       local network multicast (ff02::1), messages will be "broadcasted" until
       somebody sends data back. From then on, UDP packets will only be sent to
@@ -180,7 +180,7 @@ config file format):
       IP address. This is essentially the opposite of client mode. Messages can
       be received directly after startup, but we can only send messages out
       after the first received message, because we don't know the remote IP and
-      port otherwise.
+      port otherwise.  
       MAVLink messages are always sent to the IP and port from which the last
       incoming message was received.
   - TCP Client:
@@ -205,7 +205,7 @@ Defining endpoints:
 In general, each message received on one endpoint is delivered to all endpoints
 in which that target system/component has been seen. If it's a broadcast
 message, it's delivered to all endpoints. A message is never sent back to the
-same endpoint it came from.
+same endpoint it came from.  
 Details on broadcast rules can be found in the official
 [MAVLink documentation](http://mavlink.io/en/guide/routing.html).
 
@@ -222,7 +222,7 @@ Routing rules:
     3. Accept the message, if it's targeted to any of the systems in the list
       of connected systems on this endpoint. Broadcast rules apply when
       checking if the targeted is reachable via this endpoint. Messages without
-      target address count as broadcast.
+      target address count as broadcast.  
       If the list of connected systems is empty, only system-ID broadcast
       messages will be sent, but no component-ID broadcasts since the targeted
       system isn't known to be reachable via this endpoint.
@@ -240,8 +240,8 @@ Message filters:
   - And a message filter can either be a block- or allow-list:
     - **Block**: Discard all messages matching the respective identifier (and allow all other ones)
     - **Allow**: Allow all messages matching the respective identifier (and discard all other ones)
-    - Note that while using "Allow" and "Block" filters on the same identifier
-    within an endpoint doesn't make sense, using them on different identifiers
+    - Note that while using "Allow" and "Block" filters on the same identifier 
+    within an endpoint doesn't make sense, using them on different identifiers 
     can be useful (for example, allowing only specific outgoing SysID, and
     blocking this system from sending some unwanted message IDs).
   - So a filter might be named `AllowMsgIdOut` to only allow messages with the listed message ID to be transmitted on that endpoint. See the example config [examples/config.sample](examples/config.sample) for the exact name of each filter parameter.
@@ -252,7 +252,7 @@ Message de-duplication:
     already received the last `DeduplicationPeriod` milliseconds ago. If it's
     already known, the message will be dropped as it was never received and the
     timeout counter for that message will be reset. Messages are identified via
-    their `std::hash` value of the full MAVLink message including it's header.
+    their `std::hash` value of the full MAVLink message including it's header.  
     As long as no message with exactly the same header sequence number and
     content is received during the configured period, everything is fine. The
     most critical message is the heartbeat since it mostly contains static
@@ -262,7 +262,7 @@ Message de-duplication:
 Endpoint groups:
 
   - Multiple endpoints can be configured to be in the same endpoin group.
-    Endpoints in the same group will share the same list of connected systems.
+    Endpoints in the same group will share the same list of connected systems.  
     When using two (or more) **parallel data links**, e.g. LTE and telemetry
     radio, the endpoint **must** be grouped on both sides. Otherwise one link
     will not be used any more because of routing rule 1.
@@ -298,10 +298,10 @@ which preserves the existing behavior of stopping immediately on disarm.
 
 #### Telemetry Logging
 
-Similar to flight stack logging its also possible to write the raw telemetry
-data as `.tlog` file using the `LogTelemetry` key in the `General` section
+Similar to flight stack logging its also possible to write the raw telemetry 
+data as `.tlog` file using the `LogTelemetry` key in the `General` section 
 (or use argument `-T`). Note that this only works if a path using flight
-stack logging is set!
+stack logging is set! 
 All options from flightstack logging apply also here.
 
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -67,10 +67,15 @@
 # Default: <always>
 #LogMode = always
 
+# Delay stopping while-armed logs after disarm.
+# This leaves time for post-disarm logger data to arrive.
+# Default: 0 seconds (stop immediately on disarm).
+#LogStopDelay = 0
+
 # Preset the FCU MAVLink ID from which logs should be received. If absent, it
 # will be set to the system ID of the first flight stack heartbeat received.
 # No default value.
-#LogSystemId = 
+#LogSystemId =
 
 # Auto-delete old log files until there's at least the configured amount of
 # bytes free on the storage device. Set to 0 to disable this functionality.
@@ -88,7 +93,7 @@
 # Default: 0 (disabled)
 #SnifferSysid=254
 
-# Log raw mavlink telemetry data as tlog files to disc. Only works if Logging path 
+# Log raw mavlink telemetry data as tlog files to disc. Only works if Logging path
 # is defined. This also uses LogMode to control the recording.
 # Valid values: <true>, <false>
 # Default: <false>
@@ -104,7 +109,7 @@
 
 # Path to UART device. like `/dev/ttyS0`
 # Mandatory, no default value
-#Device = 
+#Device =
 
 # List of baudrates to use for the UART connection. The values will be cycled
 # through until valid MAVLink packets are received.
@@ -120,80 +125,80 @@
 # empty list allows all message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowMsgIdOut = 
+#AllowMsgIdOut =
 
 # Block specified MAVLink message IDs to be sent via this endpoint. An
 # empty list won't block any message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockMsgIdOut = 
+#BlockMsgIdOut =
 
 # Only allow messages from the specified MAVLink source component IDs to be
 # sent via this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcCompOut = 
+#AllowSrcCompOut =
 
 # Block messages from the specified MAVLink source component IDs to be
 # sent via this endpoint. An empty list won't block any source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcCompOut = 
+#BlockSrcCompOut =
 
 # Only allow messages from the specified MAVLink source systems to be sent via
 # this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcSysOut = 
+#AllowSrcSysOut =
 
 # Block messages from the specified MAVLink source systems to be sent via
 # this endpoint. An empty list won't block any source systems.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcSysOut = 
+#BlockSrcSysOut =
 
 # Only allow specified MAVLink message IDs to be received on this endpoint.
 # An empty list allows all message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowMsgIdIn = 
+#AllowMsgIdIn =
 
 # Block specified MAVLink message IDs to be received on this endpoint.
 # An empty list won't block any message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockMsgIdIn = 
+#BlockMsgIdIn =
 
 # Only allow messages from the specified MAVLink source component IDs to be
 # received on this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcCompIn = 
+#AllowSrcCompIn =
 
 # Block messages from the specified MAVLink source component IDs to be
 # received on this endpoint. An empty list won't block any source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcCompIn = 
+#BlockSrcCompIn =
 
 # Only allow messages from the specified MAVLink source systems to be received
 # on this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcSysIn = 
+#AllowSrcSysIn =
 
 # Block messages from the specified MAVLink source systems to be received
 # on this endpoint. An empty list won't block any source systems.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcSysIn = 
+#BlockSrcSysIn =
 
 # Group parallel/ redundant data links to use the same list of connected
 # systems. This is needed to prevent messages from one of the parallel links
 # being send back on the other one right away.
 # Set the same name (arbitrary string) on multiple endpoints to group them.
 # Default: Empty (no group)
-#Group = 
+#Group =
 
 ## Example
 [UartEndpoint alpha]
@@ -212,22 +217,22 @@ Baud = 52000
 # behavior (client mode is <normal> in the configuraiton).
 # Valid values: <normal>, <server>
 # Mandatory, no default value
-#Mode = 
+#Mode =
 
 # Binding or target IP address (depending on mode).
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Binding to `0.0.0.0` or `[::]` will listen on all interfaces.
 # Mandatory, no default value
-#Address = 
+#Address =
 
 # UDP port to be used with the configured address.
 # Mandatory in <server> mode, no default value
 # Optional in <normal> mode, will select the next port not used by mavlink-router
 #   starting from 14550 when not speciifed.
-#Port = 
+#Port =
 
 # See description at UartEndpoint
-#AllowMsgIdOut = 
+#AllowMsgIdOut =
 
 ## Examples
 # bind to 0.0.0.0:10000
@@ -253,11 +258,11 @@ Port = 11000
 # Server IP address to connect to.
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Mandatory, no default value
-#Address = 
+#Address =
 
 # TCP port to be used with the configured address.
 # Mandatory, no default value
-#Port = 
+#Port =
 
 # Enable automatic reconnect after the configured timeout in seconds. Set to 0
 # to disable reconnection.
@@ -265,7 +270,7 @@ Port = 11000
 #RetryTimeout = 5
 
 # See description at UartEndpoint
-#AllowMsgIdOut = 
+#AllowMsgIdOut =
 
 ## Example
 # connect to 127.0.0.1:25760 (e.g. another mavlink-router)

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -75,7 +75,7 @@
 # Preset the FCU MAVLink ID from which logs should be received. If absent, it
 # will be set to the system ID of the first flight stack heartbeat received.
 # No default value.
-#LogSystemId =
+#LogSystemId = 
 
 # Auto-delete old log files until there's at least the configured amount of
 # bytes free on the storage device. Set to 0 to disable this functionality.
@@ -93,7 +93,7 @@
 # Default: 0 (disabled)
 #SnifferSysid=254
 
-# Log raw mavlink telemetry data as tlog files to disc. Only works if Logging path
+# Log raw mavlink telemetry data as tlog files to disc. Only works if Logging path 
 # is defined. This also uses LogMode to control the recording.
 # Valid values: <true>, <false>
 # Default: <false>
@@ -109,7 +109,7 @@
 
 # Path to UART device. like `/dev/ttyS0`
 # Mandatory, no default value
-#Device =
+#Device = 
 
 # List of baudrates to use for the UART connection. The values will be cycled
 # through until valid MAVLink packets are received.
@@ -125,80 +125,80 @@
 # empty list allows all message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowMsgIdOut =
+#AllowMsgIdOut = 
 
 # Block specified MAVLink message IDs to be sent via this endpoint. An
 # empty list won't block any message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockMsgIdOut =
+#BlockMsgIdOut = 
 
 # Only allow messages from the specified MAVLink source component IDs to be
 # sent via this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcCompOut =
+#AllowSrcCompOut = 
 
 # Block messages from the specified MAVLink source component IDs to be
 # sent via this endpoint. An empty list won't block any source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcCompOut =
+#BlockSrcCompOut = 
 
 # Only allow messages from the specified MAVLink source systems to be sent via
 # this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcSysOut =
+#AllowSrcSysOut = 
 
 # Block messages from the specified MAVLink source systems to be sent via
 # this endpoint. An empty list won't block any source systems.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcSysOut =
+#BlockSrcSysOut = 
 
 # Only allow specified MAVLink message IDs to be received on this endpoint.
 # An empty list allows all message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowMsgIdIn =
+#AllowMsgIdIn = 
 
 # Block specified MAVLink message IDs to be received on this endpoint.
 # An empty list won't block any message IDs.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockMsgIdIn =
+#BlockMsgIdIn = 
 
 # Only allow messages from the specified MAVLink source component IDs to be
 # received on this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcCompIn =
+#AllowSrcCompIn = 
 
 # Block messages from the specified MAVLink source component IDs to be
 # received on this endpoint. An empty list won't block any source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcCompIn =
+#BlockSrcCompIn = 
 
 # Only allow messages from the specified MAVLink source systems to be received
 # on this endpoint. An empty list allows all source components.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#AllowSrcSysIn =
+#AllowSrcSysIn = 
 
 # Block messages from the specified MAVLink source systems to be received
 # on this endpoint. An empty list won't block any source systems.
 # Format: Comma separated list of integers
 # Default: Empty list (disabled)
-#BlockSrcSysIn =
+#BlockSrcSysIn = 
 
 # Group parallel/ redundant data links to use the same list of connected
 # systems. This is needed to prevent messages from one of the parallel links
 # being send back on the other one right away.
 # Set the same name (arbitrary string) on multiple endpoints to group them.
 # Default: Empty (no group)
-#Group =
+#Group = 
 
 ## Example
 [UartEndpoint alpha]
@@ -217,22 +217,22 @@ Baud = 52000
 # behavior (client mode is <normal> in the configuraiton).
 # Valid values: <normal>, <server>
 # Mandatory, no default value
-#Mode =
+#Mode = 
 
 # Binding or target IP address (depending on mode).
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Binding to `0.0.0.0` or `[::]` will listen on all interfaces.
 # Mandatory, no default value
-#Address =
+#Address = 
 
 # UDP port to be used with the configured address.
 # Mandatory in <server> mode, no default value
 # Optional in <normal> mode, will select the next port not used by mavlink-router
 #   starting from 14550 when not speciifed.
-#Port =
+#Port = 
 
 # See description at UartEndpoint
-#AllowMsgIdOut =
+#AllowMsgIdOut = 
 
 ## Examples
 # bind to 0.0.0.0:10000
@@ -258,11 +258,11 @@ Port = 11000
 # Server IP address to connect to.
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Mandatory, no default value
-#Address =
+#Address = 
 
 # TCP port to be used with the configured address.
 # Mandatory, no default value
-#Port =
+#Port = 
 
 # Enable automatic reconnect after the configured timeout in seconds. Set to 0
 # to disable reconnection.
@@ -270,7 +270,7 @@ Port = 11000
 #RetryTimeout = 5
 
 # See description at UartEndpoint
-#AllowMsgIdOut =
+#AllowMsgIdOut = 
 
 ## Example
 # connect to 127.0.0.1:25760 (e.g. another mavlink-router)

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -54,6 +54,7 @@ const ConfFile::OptionsTable LogEndpoint::option_table[] = {
     {"MaxLogFiles",     false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, max_log_files)},
     {"LogSystemId",     false, LogEndpoint::parse_fcu_id,           OPTIONS_TABLE_STRUCT_FIELD(LogOptions, fcu_id)},
     {"LogTelemetry",    false, ConfFile::parse_bool,                OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_telemetry)},
+    {"LogStopDelay",    false, ConfFile::parse_ul,                  OPTIONS_TABLE_STRUCT_FIELD(LogOptions, log_stop_delay)},
     {}
 };
 // clang-format on
@@ -367,6 +368,11 @@ void LogEndpoint::stop()
         _timeout.alive = nullptr;
     }
 
+    if (_timeout.stop_delay) {
+        mainloop.del_timeout(_timeout.stop_delay);
+        _timeout.stop_delay = nullptr;
+    }
+
     if (_timeout.fsync) {
         mainloop.del_timeout(_timeout.fsync);
         _timeout.fsync = nullptr;
@@ -434,6 +440,11 @@ logging_timeout_error:
 
 bool LogEndpoint::_alive_timeout()
 {
+    if (_timeout.stop_delay) {
+        _timeout_write_total = _stat.write.total;
+        return true;
+    }
+
     if (_timeout_write_total == _stat.write.total) {
         log_warning("No Log messages received in %u seconds restarting Log...", ALIVE_TIMEOUT);
         stop();
@@ -477,6 +488,21 @@ bool LogEndpoint::_start_alive_timeout()
     return !!_timeout.alive;
 }
 
+void LogEndpoint::_cancel_stop_delay_timeout()
+{
+    if (_timeout.stop_delay) {
+        Mainloop::get_instance().del_timeout(_timeout.stop_delay);
+        _timeout.stop_delay = nullptr;
+    }
+}
+
+bool LogEndpoint::_stop_delay_timeout()
+{
+    _timeout.stop_delay = nullptr;
+    stop();
+    return false;
+}
+
 void LogEndpoint::_handle_auto_start_stop(const struct buffer *pbuf)
 {
     // wait until initialized
@@ -502,12 +528,42 @@ void LogEndpoint::_handle_auto_start_stop(const struct buffer *pbuf)
             const mavlink_heartbeat_t *heartbeat = (mavlink_heartbeat_t *)pbuf->curr.payload;
             const bool is_armed = heartbeat->base_mode & MAV_MODE_FLAG_SAFETY_ARMED;
 
-            if (_file == -1 && is_armed) {
+            if (is_armed) {
+                _cancel_stop_delay_timeout();
+
+                if (_file != -1) {
+                    return;
+                }
+
                 if (!start()) {
                     _config.log_mode = LogMode::disabled;
                 }
             } else if (_file != -1 && !is_armed) {
-                stop();
+
+                if (_config.log_stop_delay == 0) {
+                    stop();
+                    return;
+                }
+
+                if (_config.log_stop_delay > UINT32_MAX / MSEC_PER_SEC) {
+                    log_error("LogStopDelay=%lu is too large, stopping log immediately",
+                              _config.log_stop_delay);
+                    stop();
+                    return;
+                }
+
+                if (!_timeout.stop_delay) {
+                    log_info("Stopping log in %lu seconds after disarm", _config.log_stop_delay);
+                    _timeout.stop_delay = Mainloop::get_instance().add_timeout(
+                        _config.log_stop_delay * MSEC_PER_SEC,
+                        std::bind(&LogEndpoint::_stop_delay_timeout, this),
+                        this);
+
+                    if (!_timeout.stop_delay) {
+                        log_error("Unable to add timeout");
+                        stop();
+                    }
+                }
             }
         }
     }

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -46,6 +46,7 @@ struct LogOptions {
     unsigned long max_log_files;                  // conf "MaxLogFiles"
     int fcu_id{-1};                               // conf "LogSystemId"
     bool log_telemetry{false};                    // conf "LogTelemetry"
+    unsigned long log_stop_delay{0};              // conf "LogStopDelay"
 };
 
 class LogEndpoint : public Endpoint {
@@ -77,6 +78,7 @@ protected:
         Timeout *logging_start = nullptr;
         Timeout *fsync = nullptr;
         Timeout *alive = nullptr;
+        Timeout *stop_delay = nullptr;
     } _timeout;
     uint32_t _timeout_write_total = 0;
     aiocb _fsync_cb = {};
@@ -86,11 +88,13 @@ protected:
     void _send_msg(const mavlink_message_t *msg, int target_sysid);
     void _remove_logging_start_timeout();
     bool _start_alive_timeout();
+    void _cancel_stop_delay_timeout();
 
     virtual bool _logging_start_timeout() = 0;
     virtual bool _alive_timeout();
 
     bool _fsync();
+    bool _stop_delay_timeout();
 
     void _handle_auto_start_stop(const struct buffer *pbuf);
 


### PR DESCRIPTION
When `LogMode=while-armed` is used, post-disarm data is lost. For example, in PX4 the post-flight performance counters are not logged because once the drone disarms, the `VEHICLE_CMD_LOGGING_STOP` is received (for this specific example, a separate PR in PX4 is required to log the perf counters on disarm instead of on log stop). 

Solution: add a `LogStopDelay` to keep collecting post-disarm logger data before stopping the log. It defaults to `0`, which preserves the existing behavior of stopping immediately on disarm.