### PR TITLE
logendpoint: capture point-to-point messages

### DIFF
--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -177,7 +177,7 @@ public:
         return has_sys_comp_id(sys_comp_id);
     }
 
-    AcceptState accept_msg(const struct buffer *pbuf) const;
+    virtual AcceptState accept_msg(const struct buffer *pbuf) const;
 
     void filter_add_allowed_out_msg_id(uint32_t msg_id)
     {
@@ -369,7 +369,7 @@ public:
     bool is_valid() override { return _valid; };
     bool is_critical() override { return false; };
 
-    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const;
+    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const override;
 
     int accept(int listener_fd);        ///< accept incoming connection
     bool setup(TcpEndpointConfig conf); ///< open connection and apply config

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -734,3 +734,43 @@ TEST(LogEndpointTest, Init)
     TLog tlog{conf};
     EXPECT_EQ(tlog.get_type(), ENDPOINT_TYPE_LOG);
 }
+
+TEST(LogEndpointTest, AcceptMsg_CapturesTargetedMessages)
+{
+    LogOptions conf;
+    conf.logs_dir = "./";
+
+    TLog tlog{conf};
+    buffer test_msg;
+    test_msg.curr.msg_id = 1;
+
+    // broadcast message: accepted (same as before)
+    test_msg.curr.src_sysid = 1;
+    test_msg.curr.src_compid = 1;
+    test_msg.curr.target_sysid = 0;
+    test_msg.curr.target_compid = 0;
+    EXPECT_EQ(tlog.accept_msg(&test_msg), Endpoint::AcceptState::Accepted);
+
+    // point-to-point message addressed to the FCU: must be captured even
+    // though the log endpoint has neither its sysid nor a matching sniffer
+    test_msg.curr.src_sysid = 255;
+    test_msg.curr.src_compid = 190;
+    test_msg.curr.target_sysid = 1;
+    test_msg.curr.target_compid = 1;
+    EXPECT_EQ(tlog.accept_msg(&test_msg), Endpoint::AcceptState::Accepted);
+
+    // point-to-point response from FCU back to GCS: also captured
+    test_msg.curr.src_sysid = 1;
+    test_msg.curr.src_compid = 1;
+    test_msg.curr.target_sysid = 255;
+    test_msg.curr.target_compid = 190;
+    EXPECT_EQ(tlog.accept_msg(&test_msg), Endpoint::AcceptState::Accepted);
+
+    // message emitted by the log endpoint itself is rejected to avoid
+    // logging our own outgoing control traffic
+    test_msg.curr.src_sysid = LOG_ENDPOINT_SYSTEM_ID;
+    test_msg.curr.src_compid = 0;
+    test_msg.curr.target_sysid = 1;
+    test_msg.curr.target_compid = 1;
+    EXPECT_EQ(tlog.accept_msg(&test_msg), Endpoint::AcceptState::Rejected);
+}

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -80,6 +80,23 @@ LogEndpoint::LogEndpoint(std::string name, LogOptions conf)
     }
 }
 
+Endpoint::AcceptState LogEndpoint::accept_msg(const struct buffer *pbuf) const
+{
+    // Reject messages that this log endpoint emitted itself (e.g. BinLog's
+    // remote-log control messages). Without this check, those would be
+    // written back into the log file, creating a loop.
+    if (has_sys_comp_id(pbuf->curr.src_sysid, pbuf->curr.src_compid)) {
+        return Endpoint::AcceptState::Rejected;
+    }
+
+    // Accept everything else, including point-to-point messages whose
+    // target_sysid/target_compid do not match this endpoint. A log endpoint
+    // is a passive observer of the bus, not an addressable participant, so
+    // the standard target-matching rules in Endpoint::accept_msg would
+    // otherwise drop targeted traffic like COMMAND_INT or COMMAND_ACK.
+    return Endpoint::AcceptState::Accepted;
+}
+
 void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
 {
     uint8_t data[MAVLINK_MAX_PACKET_LEN] = {};

--- a/src/logendpoint.h
+++ b/src/logendpoint.h
@@ -56,6 +56,16 @@ public:
     virtual void stop();
 
     /**
+     * Override to capture every routed message regardless of its target
+     * sysid/compid. Log endpoints are passive observers: they do not consume
+     * an address on the MAVLink network, so the standard target-matching
+     * rules in Endpoint::accept_msg would drop point-to-point traffic (e.g.
+     * COMMAND_INT, COMMAND_ACK), leaving the log with broadcast messages
+     * only.
+     */
+    Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const override;
+
+    /**
      * Check existing log files and mark logs as read-only if needed.
      * This handles the case where the system (or mavlink-router) crashed or
      * lost power.


### PR DESCRIPTION
Fixes #482

## Problem

`LogEndpoint` inherits `Endpoint::accept_msg`, which only accepts a message when the target sysid/compid matches one the endpoint owns (or the message is broadcast, or the endpoint is configured as the `SnifferSysid`). A log endpoint only registers `LOG_ENDPOINT_SYSTEM_ID = 2` in its constructor and never reads inbound traffic, so it never accumulates the FCU/GCS sysids the way a UART/UDP/TCP endpoint does, and it has no way to satisfy the sniffer rule either.

The result is what the reporter described: with the config in #482 (PX4 SITL sysid 1 + mock GCS sysid 255 + monitor sysid 254 + `LogTelemetry=true`), the `.tlog` only captures broadcast frames such as `HEARTBEAT`. Anything addressed with an explicit `target_system`/`target_component` (e.g. `COMMAND_INT`, `COMMAND_ACK`, parameter exchanges) is silently rejected by `accept_msg` and never reaches `TLog::write_msg`.

## Fix

Make `Endpoint::accept_msg` virtual and override it in `LogEndpoint` to accept every routed message, preserving the self-loop check so `BinLog`/`ULog`'s outbound `REMOTE_LOG_DATA_BLOCK` control frames (sourced from `LOG_ENDPOINT_SYSTEM_ID`) are still rejected and never written back into the log.

`TLog` becomes a true passive sniffer of the bus, which is the expected behaviour for a `.tlog`. `BinLog` and `ULog` already filter to the specific `msg_id` they care about inside their own `write_msg`, so their on-disk output is unchanged — they now just see more candidate messages from the router and discard the ones they don't want, exactly as before.

The `TcpEndpoint::accept_msg` declaration also gets an `override` keyword now that the base is virtual; the behaviour there is unchanged.

## Test

Added `LogEndpointTest.AcceptMsg_CapturesTargetedMessages` in `src/endpoints_test.cpp` covering:
- broadcast still accepted
- point-to-point GCS→FCU accepted (the case from the bug report)
- point-to-point FCU→GCS accepted
- self-sourced (`LOG_ENDPOINT_SYSTEM_ID`) still rejected to avoid log feedback

I did not have a working meson/ninja toolchain on this machine to run the full suite — reviewers please run `meson test -C build` to confirm.