### PR TITLE
ulog: bound attacker-controlled LOGGING_DATA length/offset (OOB read/write)

### DIFF
--- a/src/ulog.cpp
+++ b/src/ulog.cpp
@@ -255,8 +255,17 @@ void ULog::_logging_data_process(mavlink_logging_data_t *msg)
         _buffer_partial_len = ULOG_HEADER_SIZE;
         memcpy(_buffer_partial, msg->data, ULOG_HEADER_SIZE);
 
-        memmove(msg->data, &msg->data[ULOG_HEADER_SIZE], msg->length);
+        /*
+         * msg->length is an attacker-controlled wire field (up to 255) but
+         * msg->data[] is only sizeof(msg->data) bytes. Clamp before using it,
+         * and drop the header (shifting only the payload) so the memmove reads
+         * and writes stay inside msg->data[].
+         */
+        if (msg->length > sizeof(msg->data)) {
+            msg->length = sizeof(msg->data);
+        }
         msg->length -= ULOG_HEADER_SIZE;
+        memmove(msg->data, &msg->data[ULOG_HEADER_SIZE], msg->length);
         _waiting_header = false;
     }
 
@@ -301,6 +310,17 @@ void ULog::_logging_data_process(mavlink_logging_data_t *msg)
     }
 
     if (!msg->length) {
+        return;
+    }
+
+    /*
+     * begin (first_message_offset) and length are untrusted wire fields. Without
+     * begin <= length the subtraction underflows in uint8 and the memcpy reads far
+     * past msg->data[]; length itself must also fit msg->data[]. Drop if either
+     * relationship is violated rather than reading out of bounds.
+     */
+    if (begin > msg->length || msg->length > sizeof(msg->data)) {
+        log_warning("Invalid ULog LOGGING_DATA offset/length, dropping message");
         return;
     }
 


### PR DESCRIPTION
## Summary

`ULog::_logging_data_process()` reassembles incoming `LOGGING_DATA` frames using
three attacker-controlled fields of `mavlink_logging_data_t` (`length`,
`first_message_offset`, `data[249]`) without validating their relationship,
producing two out-of-bounds accesses on the log-reassembly path. Both are
reachable whenever a ULog logging endpoint is configured (`Log`/`logs_dir`),
from any peer that can speak MAVLink to the router (`accept_msg` does no
authentication). Same root cause as #487 and #488.

### 1. Header strip — OOB read + bounded OOB write

While `_waiting_header`, `msg->length` (≤255) is used directly as the `memmove`
count *before* the 16-byte ULog header is subtracted, and is never bounded to
`sizeof(msg->data)` (249):

```c
memmove(msg->data, &msg->data[ULOG_HEADER_SIZE], msg->length);
msg->length -= ULOG_HEADER_SIZE;
```

With `length = 255` the `memmove` reads `data[16..270]` and writes `data[0..254]`
— past the 249-byte field. In the MAVLink-2 trimmed-zeros dispatch the message is
a stack local, so the write is a small stack overflow.

### 2. Reassembly — `first_message_offset` underflow → OOB read

`begin = first_message_offset` is excluded only when `== 255`, and is never
checked against `length`:

```c
msg->length = msg->length - begin;   // uint8 underflow when begin > length
memcpy(&_buffer[...], &msg->data[begin], msg->length);
```

`length - begin` underflows in `uint8_t` (e.g. `1 - 2 → 255`); the `memcpy` then
reads up to ~255 bytes from `&data[begin]`, well past `data[]`. The over-read
bytes are persisted into the `.ulg` file.

## Fix

- Clamp `msg->length` to `sizeof(msg->data)` and drop the header *before* the
  `memmove`, so it shifts only the payload and stays in bounds.
- Reject frames where `begin > length` or `length > sizeof(data)` rather than
  reading out of bounds.

Malformed frames are dropped (with a warning) instead of crashing or leaking.

## Testing

Builds clean (`meson setup build && ninja -C build`, all targets). Well-formed
ULog streaming (header strip + offset-based reassembly) is unaffected, since
valid frames always satisfy `begin ≤ length ≤ sizeof(data)`.

Fixes #487
Fixes #488
