### PR TITLE
Add UART RetryTimeout and reconnect support for PX4 USB serial recovery

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -116,6 +116,11 @@
 # Default: <false>
 #FlowControl = false
 
+# Retry timeout in seconds when opening the UART device fails or the device is
+# disconnected. Set to 0 to disable automatic reconnect.
+# Default: 0 (disabled)
+#RetryTimeout = 5
+
 # Only allow specified MAVLink message IDs to be sent via this endpoint. An
 # empty list allows all message IDs.
 # Format: Comma separated list of integers

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -60,6 +60,7 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"baud",            false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, baudrates)},
     {"device",          true,  ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, device)},
     {"FlowControl",     false, ConfFile::parse_bool,            OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, flowcontrol)},
+    {"RetryTimeout",    false, ConfFile::parse_i,               OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false, ConfFile::parse_uint32_vector,   OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_msg_id_out)},
     {"AllowSrcCompOut", false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_comp_out)},
@@ -733,25 +734,11 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
         return false;
     }
 
-    if (!this->open(conf.device.c_str())) {
-        return false;
-    }
-
-    if (conf.baudrates.size() == 1) {
-        if (this->set_speed(conf.baudrates[0]) < 0) {
-            return false;
-        }
-    } else {
-        if (this->add_speeds(conf.baudrates) < 0) {
-            return false;
-        }
-    }
-
-    if (conf.flowcontrol) {
-        if (this->set_flow_control(true) < 0) {
-            return false;
-        }
-    }
+    _device = conf.device;
+    _flowcontrol = conf.flowcontrol;
+    _retry_timeout_interval = conf.retry_timeout;
+    _baudrates = conf.baudrates;
+    _current_baud_idx = 0;
 
     for (auto msg_id : conf.allow_msg_id_out) {
         this->filter_add_allowed_out_msg_id(msg_id);
@@ -792,6 +779,21 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     }
 
     this->_group_name = conf.group;
+
+    if (_baudrates.empty()) {
+        _baudrates.push_back(DEFAULT_BAUDRATE);
+    }
+
+    if (!this->open(_device.c_str()) || !_configure_port()) {
+        if (_retry_timeout_interval > 0) {
+            log_warning("Could not open UART %s. Re-trying every %d sec",
+                        _device.c_str(),
+                        _retry_timeout_interval);
+            _schedule_reconnect();
+            return true;
+        }
+        return false;
+    }
 
     return true;
 }
@@ -951,6 +953,101 @@ fail:
     return false;
 }
 
+void UartEndpoint::_close()
+{
+    if (fd >= 0) {
+        Mainloop::get_instance().remove_fd(fd);
+        ::close(fd);
+        log_info("UART [%d]%s: Connection closed", fd, _name.c_str());
+        fd = -1;
+    }
+
+    if (_change_baud_timeout != nullptr) {
+        Mainloop::get_instance().del_timeout(_change_baud_timeout);
+        _change_baud_timeout = nullptr;
+    }
+}
+
+bool UartEndpoint::_configure_port()
+{
+    if (_baudrates.empty()) {
+        return false;
+    }
+
+    if (_baudrates.size() == 1) {
+        if (set_speed(_baudrates[0]) < 0) {
+            return false;
+        }
+    } else {
+        if (add_speeds(_baudrates) < 0) {
+            return false;
+        }
+    }
+
+    if (_flowcontrol) {
+        if (set_flow_control(true) < 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool UartEndpoint::_retry_timeout_cb(void *data)
+{
+    auto *uart = static_cast<UartEndpoint *>(data);
+    if (!uart->reopen()) {
+        return true;
+    }
+
+    uart->_retry_timeout_timer = nullptr;
+    return false;
+}
+
+void UartEndpoint::_schedule_reconnect()
+{
+    if (_retry_timeout_interval <= 0) {
+        return;
+    }
+
+    if (_retry_timeout_timer != nullptr) {
+        return;
+    }
+
+    _close();
+
+    _retry_timeout_timer = Mainloop::get_instance().add_timeout(
+        MSEC_PER_SEC * _retry_timeout_interval,
+        std::bind(&UartEndpoint::_retry_timeout_cb, this, std::placeholders::_1),
+        this);
+
+    if (_retry_timeout_timer == nullptr) {
+        log_warning("Could not create retry timeout for UART %s\n"
+                    "No attempts to reconnect will be made",
+                    _device.c_str());
+    }
+}
+
+bool UartEndpoint::reopen()
+{
+    if (_retry_timeout_timer != nullptr) {
+        Mainloop::get_instance().del_timeout(_retry_timeout_timer);
+        _retry_timeout_timer = nullptr;
+    }
+
+    if (!this->open(_device.c_str()) || !_configure_port()) {
+        return false;
+    }
+
+    if (Mainloop::get_instance().add_fd(fd, this, EPOLLIN) < 0) {
+        _close();
+        return false;
+    }
+
+    log_info("UART [%d]%s: Reconnected to %s", fd, _name.c_str(), _device.c_str());
+    return true;
+}
+
 bool UartEndpoint::_change_baud_cb(void *data)
 {
     _current_baud_idx = (_current_baud_idx + 1) % _baudrates.size();
@@ -985,10 +1082,25 @@ int UartEndpoint::read_msg(struct buffer *pbuf)
 ssize_t UartEndpoint::_read_msg(uint8_t *buf, size_t len)
 {
     ssize_t r = ::read(fd, buf, len);
-    if ((r == -1 && errno == EAGAIN) || r == 0) {
+    if (r == 0) {
+        log_warning("UART [%d]%s: Device disconnected", fd, _name.c_str());
+        _schedule_reconnect();
         return 0;
     }
+
     if (r == -1) {
+        if (errno == EAGAIN) {
+            return 0;
+        }
+
+        if (errno == EBADF || errno == EIO || errno == ENODEV) {
+            log_warning("UART [%d]%s: Permanent read error (%m), scheduling reconnect",
+                        fd,
+                        _name.c_str());
+            _schedule_reconnect();
+            return 0;
+        }
+
         return -errno;
     }
 
@@ -1035,7 +1147,13 @@ int UartEndpoint::add_speeds(const std::vector<speed_t> &bauds)
         return -EINVAL;
     }
 
+    if (_change_baud_timeout != nullptr) {
+        Mainloop::get_instance().del_timeout(_change_baud_timeout);
+        _change_baud_timeout = nullptr;
+    }
+
     _baudrates = bauds;
+    _current_baud_idx = 0;
 
     set_speed(_baudrates[0]);
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -41,6 +41,7 @@ struct UartEndpointConfig {
     std::string device;
     std::vector<uint32_t> baudrates;
     bool flowcontrol{false};
+    int retry_timeout{0};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint32_t> block_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
@@ -305,6 +306,11 @@ public:
     static const char *section_pattern;
     static bool validate_config(const UartEndpointConfig &config);
 
+    int get_retry_timeout() const { return _retry_timeout_interval; }
+    bool retry_timer_active() const { return _retry_timeout_timer != nullptr; }
+
+    bool is_critical() override { return false; }
+
 protected:
     bool open(const char *path);
     int set_speed(speed_t baudrate);
@@ -313,8 +319,19 @@ protected:
 
     int read_msg(struct buffer *pbuf) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
+    bool _retry_timeout_cb(void *data);
+    bool reopen();
+    void _schedule_reconnect();
+
+    std::string _device;
+    bool _flowcontrol = false;
+    int _retry_timeout_interval = 0;
+    Timeout *_retry_timeout_timer = nullptr;
 
 private:
+    void _close();
+    bool _configure_port();
+
     size_t _current_baud_idx = 0;
     Timeout *_change_baud_timeout = nullptr;
     std::vector<uint32_t> _baudrates;

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -19,10 +19,13 @@
 #include "autolog.h"
 #include "binlog.h"
 #include "endpoint.h"
+#include "mainloop.h"
 #include "tlog.h"
 #include "ulog.h"
 
+#include <fcntl.h>
 #include <limits.h>
+#include <unistd.h>
 
 #include <gtest/gtest.h>
 
@@ -45,6 +48,14 @@ public:
     // expose some internal data
     void set_sys_comp_ids(std::vector<uint16_t> sys_comp_ids) { _sys_comp_ids = sys_comp_ids; };
     std::vector<uint16_t> get_sys_comp_ids() { return _sys_comp_ids; };
+};
+
+class TestUartEndpoint : public UartEndpoint {
+public:
+    explicit TestUartEndpoint(std::string name)
+        : UartEndpoint(std::move(name)) {}
+
+    using UartEndpoint::read_msg;
 };
 
 static uint16_t build_sys_comp_id(unsigned sysid, unsigned compid)
@@ -557,6 +568,80 @@ TEST(UartEndpointTest, ConfigValidateDevice)
     // build invalid baud rate
     config.device = "";
     EXPECT_FALSE(UartEndpoint::validate_config(config)) << "with device " << config.device;
+}
+
+TEST(UartEndpointTest, SetupWithMissingDeviceSchedulesRetry)
+{
+    Mainloop &mainloop = Mainloop::init();
+    ASSERT_EQ(0, mainloop.open());
+
+    UartEndpointConfig config;
+    config.device = "/dev/ttyFake";
+    config.baudrates.push_back(115200);
+    config.retry_timeout = 1;
+
+    UartEndpoint uart{"testname"};
+    EXPECT_TRUE(uart.setup(config));
+    EXPECT_EQ(1, uart.get_retry_timeout());
+    EXPECT_TRUE(uart.retry_timer_active());
+
+    mainloop.request_exit(0);
+    EXPECT_EQ(0, mainloop.loop());
+    mainloop.teardown();
+}
+
+static int open_pty_slave(std::string &device)
+{
+    int master = posix_openpt(O_RDWR | O_NOCTTY);
+    if (master < 0) {
+        return -1;
+    }
+
+    if (grantpt(master) < 0 || unlockpt(master) < 0) {
+        close(master);
+        return -1;
+    }
+
+    char buf[256];
+    if (ptsname_r(master, buf, sizeof(buf)) != 0) {
+        close(master);
+        return -1;
+    }
+
+    device = buf;
+    return master;
+}
+
+TEST(UartEndpointTest, RuntimeDisconnectSchedulesRetry)
+{
+    Mainloop &mainloop = Mainloop::init();
+    ASSERT_EQ(0, mainloop.open());
+
+    std::string device;
+    int master = open_pty_slave(device);
+    ASSERT_GE(master, 0);
+
+    UartEndpointConfig config;
+    config.device = device;
+    config.baudrates.push_back(115200);
+    config.retry_timeout = 1;
+
+    TestUartEndpoint uart{"testname"};
+    EXPECT_TRUE(uart.setup(config));
+    EXPECT_GE(uart.fd, 0);
+    EXPECT_FALSE(uart.retry_timer_active());
+
+    close(master);
+
+    buffer buf;
+    int ret = uart.read_msg(&buf);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(-1, uart.fd);
+    EXPECT_TRUE(uart.retry_timer_active());
+
+    mainloop.request_exit(0);
+    EXPECT_EQ(0, mainloop.loop());
+    mainloop.teardown();
 }
 
 /**

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -66,7 +66,12 @@ Mainloop &Mainloop::init()
 
 void Mainloop::teardown()
 {
+    if (_instance.epollfd != -1) {
+        close(_instance.epollfd);
+        _instance.epollfd = -1;
+    }
     _initialized = false;
+    should_exit.store(false, std::memory_order_relaxed);
 }
 
 Mainloop &Mainloop::instance()
@@ -376,7 +381,9 @@ bool Mainloop::add_endpoints(const Configuration &config)
 
         g_endpoints.push_back(uart);
         auto endpoint = g_endpoints.back();
-        this->add_fd(endpoint->fd, endpoint.get(), EPOLLIN);
+        if (endpoint->fd >= 0) {
+            this->add_fd(endpoint->fd, endpoint.get(), EPOLLIN);
+        }
     }
 
     for (const auto &conf : config.udp_configs) {


### PR DESCRIPTION
## Summary of work completed

- Added `RetryTimeout` to `UartEndpointConfig` and UART config parsing.
- Updated `UartEndpoint::setup()` so initial open failure is non-fatal when retry is enabled.
- Implemented reconnect scheduling:
  - `_schedule_reconnect()`
  - `_retry_timeout_cb()`
  - `reopen()`
  - `_close()` / `_configure_port()`
- Detected runtime UART failures in `UartEndpoint::_read_msg()` and scheduled reconnect instead of exiting.
- Added/updated unit tests in endpoints_test.cpp for:
  - missing device retry scheduling
  - runtime disconnect retry scheduling
- Documented `RetryTimeout` in config.sample.
- Verified with `ninja -C build test` and created branch `uart-reconnect-retry-timeout` with the commit.