### PR TITLE
logendpoint: reopen log file if deleted externally while open

### DIFF
--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -454,6 +454,18 @@ bool LogEndpoint::_fsync()
         // previous operation is still in progress
         return true;
     }
+
+    // Detect external deletion: st_nlink == 0 means the file was unlinked
+    // from the filesystem while we still hold an open fd. Reopen a new file
+    // so that logging is not silently lost.
+    struct stat st;
+    if (fstat(_file, &st) == 0 && st.st_nlink == 0) {
+        log_warning("Log file was deleted externally, reopening");
+        stop();
+        start();
+        return true;
+    }
+
     _fsync_cb.aio_fildes = _file;
     _fsync_cb.aio_sigevent.sigev_notify = SIGEV_NONE;
 


### PR DESCRIPTION
## Problem

When a log file is deleted from the filesystem (e.g. via `rm`) while mavlink-router is actively writing to it, logging continues silently to the now-invisible inode. On Linux, `unlink()` only removes the directory entry — the inode and data survive until all file descriptors are closed. Since mavlink-router never detects the deletion, `write()` keeps succeeding, the file never reappears in the directory, and all subsequent log data is lost without any warning.

This affects both `LogMode = always` and `LogMode = while-armed`. A common trigger is log rotation or manual cleanup of the log directory while the daemon is running.

## Fix

Add an `fstat(st_nlink)` check in the periodic `_fsync` callback (which fires every second). A link count of zero means the file has been unlinked from all directories while the fd is still open. In that case:

1. `stop()` closes the stale fd and cleans up state
2. `start()` immediately opens a fresh log file

This is safe to do from within the `_fsync` timeout callback because `del_timeout()` only sets `remove_me = true` — the `Timeout` object is freed later in `_del_timeouts()` after all callbacks have completed, avoiding re-entrancy issues.

## Testing

```bash
# Start mavlink-router with LogMode = always
# Verify tlog file is created in the log directory
# Delete the file while router is running:
rm /path/to/logs/*.tlog
# Wait ~1 second (next fsync tick)
# Verify a new tlog file is created and logging resumes
```