### PR TITLE
CI: Omit "float-equal" warning in dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,10 +109,10 @@ jobs:
           overwrite: true
 
   alpine-linux:
-    name: alpine 3.14 (musl)
+    name: alpine 3.23 (musl)
     runs-on: ubuntu-24.04
     needs: [formatting-check]
-    container: alpine:3.14
+    container: alpine:3.23
     steps:
       - name: install dependencies
         run: apk update && apk add build-base git linux-headers pkgconf meson ninja

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run clang-format style check on src directory
-        uses: jidicula/clang-format-action@v4.11.0
+        uses: jidicula/clang-format-action@v4.18.0
         with:
           clang-format-version: "13"
           check-path: "src"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run clang-format style check on src directory
         uses: jidicula/clang-format-action@v4.18.0
         with:
@@ -32,7 +32,7 @@ jobs:
           - name: i686
             arch: native
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0  # otherwise the version header just contains the commit hash
@@ -117,10 +117,10 @@ jobs:
       - name: install dependencies
         run: apk update && apk add build-base git linux-headers pkgconf meson ninja
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
-          fetch-depth: 0  # otherwise the version header just contains the commit hash
+          fetch-depth: 0 # otherwise the version header just contains the commit hash
 
       - name: configure
         run: meson setup --werror -Dsystemdsystemunitdir=/usr/lib/systemd/system build .

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
         version: '3',
         license: 'Apache 2.0',
         default_options: [
-                'cpp_std=gnu++14',
+                'cpp_std=gnu++17',
                 'prefix=/usr',
                 'warning_level=2',
                 'buildtype=debugoptimized',

--- a/src/mainloop_test.cpp
+++ b/src/mainloop_test.cpp
@@ -1,6 +1,9 @@
 #include "mainloop.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
 #include <gtest/gtest.h>
+#pragma GCC diagnostic pop
 
 TEST(MainLoopTest, termination)
 {


### PR DESCRIPTION
The "gtest" library uses some exact float comparison for some reason which is disallowed by our default compiler flags (which enable the "float-equal" warning and use warnings as errors".

This PR attempts to only apply the compiler warnings to our sources, but not the dependencies.

Builds on top of #483 which fixes some deprecated CI dependencies.