### PR TITLE
Add static source port support for Udp/Tcp endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ line options. The most important facts are:
   - TCP and UDP endpoints can be added multiple times
   - UDP endpoints added with the `-e` option are started in `normal` mode
     (sending data to the specified address and port)
+  - A fixed local (send) port can be requested for `-e` UDP endpoints by
+    appending `@<sendport>` to the argument, where `<sendport>` is a plain
+    port number (e.g. `14580`). The socket is then bound to this local port
+    instead of an OS-assigned ephemeral one, so the remote side always knows
+    where to send data back. If the send port cannot be bound (e.g. it's
+    already in use), mavlink-router prints a warning and falls back to a
+    dynamic port
+  - The same fixed local (send) port can be requested for `-p` TCP endpoints
+    by appending `@<sendport>` to the argument. The TCP socket is then bound
+    to this local source port before connecting, so the remote side always
+    sees the connection coming from this known port. If the send port cannot
+    be bound (e.g. it's already in use), mavlink-router prints a warning and
+    falls back to a dynamic port
   - The last parameter (without a key) can either be one UART device or an UDP
     connection. This UDP endpoint will be started in `server` mode (waiting for
     an incoming connection)!
@@ -126,6 +139,26 @@ following command:
 
 The `1500000` after the colon in `/dev/ttyS1:1500000` sets the UART baudrate.
 See more options with `mavlink-routerd --help`.
+
+A fixed local (send) port can be requested for a UDP endpoint by appending
+`@<sendport>` to the endpoint argument:
+
+    $ mavlink-routerd -e 192.168.7.1:14550@14580 /dev/ttyS1:1500000
+
+This sends to `192.168.7.1:14550` from the fixed local port `14580`. The
+`<sendport>` part is a plain port number; the same can be configured with the
+`SendPort` key in the config file (see
+[examples/config.sample](examples/config.sample)). If the send port cannot be
+bound (e.g. it's already in use), mavlink-router prints a warning and falls
+back to a dynamic port.
+
+The same syntax works for TCP endpoints given with the `-p` option:
+
+    $ mavlink-routerd -p 192.168.7.1:14550@14580 /dev/ttyS1:1500000
+
+This connects to `192.168.7.1:14550` from the fixed local (source) port
+`14580`, which can also be configured with the `SendPort` key of a
+`TcpEndpoint` section in the config file.
 
 It's also possible to route mavlinks packets from an incoming UDP connection
 instead of UART:
@@ -165,11 +198,18 @@ config file format):
     * Configuration: UART device path/name and baudrate
     * Behavior: Data is received and sent without waiting for incoming data first
   - UDP:
-    * Configuration: Mode (client or server), IP address and port
+    * Configuration: Mode (client or server), IP address and port. In client
+      mode, a fixed local (send) port can be configured with the `SendPort`
+      key or the `@<sendport>` CLI syntax
     * Behavior in client mode: Endpoint is configured with a target IP and port
       combination. So MAVLink messages can be sent directly after startup, but
       will only be recevied after the first message was received by the remote
       side, it doesn't know our IP and port otherwise.  
+      By default, the local (send) port of the socket is assigned dynamically
+      by the operating system. When a fixed send port is configured, the socket
+      is bound to it instead, so the remote side can always send data back to
+      this known port. If that port cannot be bound (e.g. it's already in
+      use), mavlink-router prints a warning and falls back to a dynamic port.  
       When using any non-unicast IP address, e.g. an IPv4 broadcast or IPv6
       local network multicast (ff02::1), messages will be "broadcasted" until
       somebody sends data back. From then on, UDP packets will only be sent to
@@ -185,9 +225,16 @@ config file format):
       incoming message was received.
   - TCP Client:
     * Configuration: Target IP address and port, reconnection interval in case
-      of disconnection
+      of disconnection. A fixed local (send) port can be configured with the
+      `SendPort` key or the `@<sendport>` CLI syntax
     * Behavior: Data is received and sent right after the TCP session is
-      established
+      established  
+      By default, the local (source) port of the TCP connection is assigned
+      dynamically by the operating system. When a fixed send port is
+      configured, the socket is bound to it before connecting, so the remote
+      side always sees the connection coming from this known port. If that
+      port cannot be bound (e.g. it's already in use), mavlink-router prints a
+      warning and falls back to a dynamic port.
 
 Defining endpoints:
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ line options. The most important facts are:
   - UDP endpoints added with the `-e` option are started in `normal` mode
     (sending data to the specified address and port)
   - A fixed local (send) port can be requested for `-e` UDP endpoints by
-    appending `@<sendport>` to the argument, where `<sendport>` is a plain
+    appending `@<sourceport>` to the argument, where `<sourceport>` is a plain
     port number (e.g. `14580`). The socket is then bound to this local port
     instead of an OS-assigned ephemeral one, so the remote side always knows
     where to send data back. If the send port cannot be bound (e.g. it's
     already in use), mavlink-router prints a warning and falls back to a
     dynamic port
   - The same fixed local (send) port can be requested for `-p` TCP endpoints
-    by appending `@<sendport>` to the argument. The TCP socket is then bound
+    by appending `@<sourceport>` to the argument. The TCP socket is then bound
     to this local source port before connecting, so the remote side always
     sees the connection coming from this known port. If the send port cannot
     be bound (e.g. it's already in use), mavlink-router prints a warning and
@@ -141,13 +141,13 @@ The `1500000` after the colon in `/dev/ttyS1:1500000` sets the UART baudrate.
 See more options with `mavlink-routerd --help`.
 
 A fixed local (send) port can be requested for a UDP endpoint by appending
-`@<sendport>` to the endpoint argument:
+`@<sourceport>` to the endpoint argument:
 
     $ mavlink-routerd -e 192.168.7.1:14550@14580 /dev/ttyS1:1500000
 
 This sends to `192.168.7.1:14550` from the fixed local port `14580`. The
-`<sendport>` part is a plain port number; the same can be configured with the
-`SendPort` key in the config file (see
+`<sourceport>` part is a plain port number; the same can be configured with the
+`SourcePort` key in the config file (see
 [examples/config.sample](examples/config.sample)). If the send port cannot be
 bound (e.g. it's already in use), mavlink-router prints a warning and falls
 back to a dynamic port.
@@ -157,7 +157,7 @@ The same syntax works for TCP endpoints given with the `-p` option:
     $ mavlink-routerd -p 192.168.7.1:14550@14580 /dev/ttyS1:1500000
 
 This connects to `192.168.7.1:14550` from the fixed local (source) port
-`14580`, which can also be configured with the `SendPort` key of a
+`14580`, which can also be configured with the `SourcePort` key of a
 `TcpEndpoint` section in the config file.
 
 It's also possible to route mavlinks packets from an incoming UDP connection
@@ -199,8 +199,8 @@ config file format):
     * Behavior: Data is received and sent without waiting for incoming data first
   - UDP:
     * Configuration: Mode (client or server), IP address and port. In client
-      mode, a fixed local (send) port can be configured with the `SendPort`
-      key or the `@<sendport>` CLI syntax
+      mode, a fixed local (send) port can be configured with the `SourcePort`
+      key or the `@<sourceport>` CLI syntax
     * Behavior in client mode: Endpoint is configured with a target IP and port
       combination. So MAVLink messages can be sent directly after startup, but
       will only be recevied after the first message was received by the remote
@@ -226,7 +226,7 @@ config file format):
   - TCP Client:
     * Configuration: Target IP address and port, reconnection interval in case
       of disconnection. A fixed local (send) port can be configured with the
-      `SendPort` key or the `@<sendport>` CLI syntax
+      `SourcePort` key or the `@<sourceport>` CLI syntax
     * Behavior: Data is received and sent right after the TCP session is
       established  
       By default, the local (source) port of the TCP connection is assigned

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -226,6 +226,16 @@ Baud = 52000
 #   starting from 14550 when not speciifed.
 #Port = 
 
+# Fixed local UDP (send) port for this endpoint in <normal> (client) mode.
+# When set, the socket is bound to this port instead of an OS-assigned
+# ephemeral port, so the remote side always knows where to send data back.
+# If the port cannot be bound (e.g. it's already in use), mavlink-router
+# prints a warning and falls back to a dynamic port.
+# Only used in <normal> mode, ignored (with a warning) in <server> mode.
+# Valid values: 1-65535
+# Default: 0 (dynamic, OS-assigned source port)
+#SendPort = 14580
+
 # See description at UartEndpoint
 #AllowMsgIdOut = 
 
@@ -242,6 +252,13 @@ Mode = Normal
 Address = 127.0.0.1
 Port = 11000
 
+# send to 127.0.0.1:11000 from the fixed local (send) port 14580
+[UdpEndpoint charlie]
+Mode = Normal
+Address = 127.0.0.1
+Port = 11000
+SendPort = 14580
+
 
 ##
 ## TCP Client Endpoint Configurations
@@ -257,7 +274,16 @@ Port = 11000
 
 # TCP port to be used with the configured address.
 # Mandatory, no default value
-#Port = 
+#Port =
+
+# Fixed local (send) port for this endpoint. When set, the socket is bound to
+# this port before connecting, so the remote side always sees the connection
+# coming from this known source port. If the port cannot be bound (e.g. it's
+# already in use), mavlink-router prints a warning and falls back to a
+# dynamic port.
+# Valid values: 1-65535
+# Default: 0 (dynamic, OS-assigned source port)
+#SendPort = 14580
 
 # Enable automatic reconnect after the configured timeout in seconds. Set to 0
 # to disable reconnection.
@@ -272,3 +298,9 @@ Port = 11000
 [TcpEndpoint delta]
 Address = 127.0.0.1
 Port = 25760
+
+# connect to 127.0.0.1:25760 from the fixed local (send) port 14580
+[TcpEndpoint epsilon]
+Address = 127.0.0.1
+Port = 25760
+SendPort = 14580

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -234,7 +234,7 @@ Baud = 52000
 # Only used in <normal> mode, ignored (with a warning) in <server> mode.
 # Valid values: 1-65535
 # Default: 0 (dynamic, OS-assigned source port)
-#SendPort = 14580
+#SourcePort = 14580
 
 # See description at UartEndpoint
 #AllowMsgIdOut = 
@@ -257,7 +257,7 @@ Port = 11000
 Mode = Normal
 Address = 127.0.0.1
 Port = 11000
-SendPort = 14580
+SourcePort = 14580
 
 
 ##
@@ -283,7 +283,7 @@ SendPort = 14580
 # dynamic port.
 # Valid values: 1-65535
 # Default: 0 (dynamic, OS-assigned source port)
-#SendPort = 14580
+#SourcePort = 14580
 
 # Enable automatic reconnect after the configured timeout in seconds. Set to 0
 # to disable reconnection.
@@ -303,4 +303,4 @@ Port = 25760
 [TcpEndpoint epsilon]
 Address = 127.0.0.1
 Port = 25760
-SendPort = 14580
+SourcePort = 14580

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -81,7 +81,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
-    {"SendPort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, send_port)},
+    {"SourcePort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, send_port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
@@ -103,7 +103,7 @@ const char *TcpEndpoint::section_pattern = "tcpendpoint *";
 const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
-    {"SendPort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, send_port)},
+    {"SourcePort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, send_port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},
@@ -1085,7 +1085,7 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     }
 
     if (conf.mode == UdpEndpointConfig::Mode::Server && conf.send_port != 0) {
-        log_warning("UDP %s: SendPort is only used in client (normal) mode, ignoring it",
+        log_warning("UDP %s: SourcePort is only used in client (normal) mode, ignoring it",
                     conf.name.c_str());
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -81,7 +81,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
-    {"SourcePort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, send_port)},
+    {"SourcePort",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, send_port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
@@ -103,7 +103,7 @@ const char *TcpEndpoint::section_pattern = "tcpendpoint *";
 const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
-    {"SourcePort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, send_port)},
+    {"SourcePort",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, send_port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -81,6 +81,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
+    {"SendPort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, send_port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
@@ -102,6 +103,7 @@ const char *TcpEndpoint::section_pattern = "tcpendpoint *";
 const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
+    {"SendPort",        false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, send_port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},
@@ -1082,7 +1084,12 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
         return false;
     }
 
-    if (!this->open(conf.address.c_str(), conf.port, conf.mode)) {
+    if (conf.mode == UdpEndpointConfig::Mode::Server && conf.send_port != 0) {
+        log_warning("UDP %s: SendPort is only used in client (normal) mode, ignoring it",
+                    conf.name.c_str());
+    }
+
+    if (!this->open(conf.address.c_str(), conf.port, conf.mode, conf.send_port)) {
         log_error("Could not open %s:%ld", conf.address.c_str(), conf.port);
         return false;
     }
@@ -1130,7 +1137,8 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     return true;
 }
 
-int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode)
+int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
+                           unsigned long send_port)
 {
     fd = socket(AF_INET6, SOCK_DGRAM, 0);
     if (fd < 0) {
@@ -1179,6 +1187,27 @@ int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig
         sockaddr6.sin6_port = 0;
     }
 
+    /* Bind a fixed local (send) port for client mode, if requested.
+     * The socket is bound to any local interface.
+     * On failure, warn and fall back to a dynamic (OS-assigned) port. */
+    if (mode == UdpEndpointConfig::Mode::Client && send_port != 0) {
+        struct sockaddr_in6 bind_addr {};
+        bind_addr.sin6_family = AF_INET6;
+        bind_addr.sin6_port = htons(send_port);
+        bind_addr.sin6_addr = in6addr_any;
+
+        if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+            log_warning("UDP %s: Could not bind fixed send port %lu for [%s]:%lu (%m), "
+                        "falling back to dynamic port",
+                        _name.c_str(),
+                        send_port,
+                        ip_str,
+                        port);
+        } else {
+            log_info("UDP %s: Using fixed send port %lu", _name.c_str(), send_port);
+        }
+    }
+
     config_sock.v6 = sockaddr6;
 
     free(ip_str);
@@ -1191,7 +1220,8 @@ fail:
     return -EINVAL;
 }
 
-int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode)
+int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
+                           unsigned long send_port)
 {
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
@@ -1202,6 +1232,27 @@ int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig
     sockaddr.sin_family = AF_INET;
     sockaddr.sin_addr.s_addr = inet_addr(ip);
     sockaddr.sin_port = htons(port);
+
+    /* Bind a fixed local (send) port for client mode, if requested.
+     * The socket is bound to any local interface.
+     * On failure, warn and fall back to a dynamic (OS-assigned) port. */
+    if (mode == UdpEndpointConfig::Mode::Client && send_port != 0) {
+        struct sockaddr_in bind_addr {};
+        bind_addr.sin_family = AF_INET;
+        bind_addr.sin_port = htons(send_port);
+        bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+        if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+            log_warning("UDP %s: Could not bind fixed send port %lu for %s:%lu (%m), "
+                        "falling back to dynamic port",
+                        _name.c_str(),
+                        send_port,
+                        ip,
+                        port);
+        } else {
+            log_info("UDP %s: Using fixed send port %lu for %s:%lu", _name.c_str(), send_port, ip, port);
+        }
+    }
 
     if (mode == UdpEndpointConfig::Mode::Server) {
         if (bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) < 0) {
@@ -1221,7 +1272,8 @@ fail:
     return -EINVAL;
 }
 
-bool UdpEndpoint::open(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode)
+bool UdpEndpoint::open(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
+                       unsigned long send_port)
 {
     const int broadcast_val = 1;
 
@@ -1229,9 +1281,9 @@ bool UdpEndpoint::open(const char *ip, unsigned long port, UdpEndpointConfig::Mo
 
     // setup the special IPv6/IPv4 part
     if (this->is_ipv6) {
-        open_ipv6(ip, port, mode);
+        open_ipv6(ip, port, mode, send_port);
     } else {
-        open_ipv4(ip, port, mode);
+        open_ipv4(ip, port, mode, send_port);
     }
 
     if (fd < 0) {
@@ -1429,6 +1481,11 @@ bool UdpEndpoint::validate_config(const UdpEndpointConfig &config)
         return false;
     }
 
+    if (config.send_port > 65535) {
+        log_error("UdpEndpoint %s: Invalid send port %lu", config.name.c_str(), config.send_port);
+        return false;
+    }
+
     if (config.mode != UdpEndpointConfig::Mode::Client
         && config.mode != UdpEndpointConfig::Mode::Server) {
         return false;
@@ -1457,6 +1514,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
     this->_ip = conf.address;
     this->_port = conf.port;
+    this->_send_port = conf.send_port;
     this->_retry_timeout = conf.retry_timeout;
 
     for (auto msg_id : conf.allow_msg_id_out) {
@@ -1499,7 +1557,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
     this->_group_name = conf.group;
 
-    if (!this->open(conf.address, conf.port)) {
+    if (!this->open(conf.address, conf.port, conf.send_port)) {
         log_warning("Could not open %s:%ld, re-trying every %d sec",
                     conf.address.c_str(),
                     conf.port,
@@ -1516,7 +1574,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
 bool TcpEndpoint::reopen()
 {
-    return this->open(_ip, _port);
+    return this->open(_ip, _port, _send_port);
 }
 
 int TcpEndpoint::accept(int listener_fd)
@@ -1551,7 +1609,8 @@ int TcpEndpoint::accept(int listener_fd)
     return fd;
 }
 
-int TcpEndpoint::open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6)
+int TcpEndpoint::open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6,
+                           unsigned long send_port)
 {
     auto fd = socket(AF_INET6, SOCK_STREAM, 0);
     if (fd == -1) {
@@ -1578,6 +1637,36 @@ int TcpEndpoint::open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &soc
         sockaddr6.sin6_scope_id = ipv6_get_scope_id(ip_str);
     }
 
+    /* Bind a fixed local (send) port, if requested. The socket is bound to
+     * any local interface. On failure, warn and fall back to a dynamic
+     * (OS-assigned) port. */
+    if (send_port != 0) {
+        struct sockaddr_in6 bind_addr {};
+        bind_addr.sin6_family = AF_INET6;
+        bind_addr.sin6_port = htons(send_port);
+        bind_addr.sin6_addr = in6addr_any;
+
+        /* allow rebinding the same send port on reconnect, while old sockets
+         * of previous connections may still be in TIME_WAIT */
+        const int reuse = 1;
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+            log_warning("TCP %s: Could not set SO_REUSEADDR for fixed send port %lu (%m)",
+                        _name.c_str(),
+                        send_port);
+        }
+
+        if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+            log_warning("TCP %s: Could not bind fixed send port %lu for [%s]:%lu (%m), "
+                        "falling back to dynamic port",
+                        _name.c_str(),
+                        send_port,
+                        ip_str,
+                        port);
+        } else {
+            log_info("TCP %s: Using fixed send port %lu", _name.c_str(), send_port);
+        }
+    }
+
     free(ip_str);
 
     return fd;
@@ -1588,12 +1677,43 @@ fail:
     return fd;
 }
 
-int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr)
+int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr,
+                           unsigned long send_port)
 {
     auto fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1) {
         log_error("Could not create IPv4 socket for %s:%lu (%m)", ip, port);
         return -1;
+    }
+
+    /* Bind a fixed local (send) port, if requested. The socket is bound to
+     * any local interface. On failure, warn and fall back to a dynamic
+     * (OS-assigned) port. */
+    if (send_port != 0) {
+        struct sockaddr_in bind_addr {};
+        bind_addr.sin_family = AF_INET;
+        bind_addr.sin_port = htons(send_port);
+        bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+        /* allow rebinding the same send port on reconnect, while old sockets
+         * of previous connections may still be in TIME_WAIT */
+        const int reuse = 1;
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+            log_warning("TCP %s: Could not set SO_REUSEADDR for fixed send port %lu (%m)",
+                        _name.c_str(),
+                        send_port);
+        }
+
+        if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+            log_warning("TCP %s: Could not bind fixed send port %lu for %s:%lu (%m), "
+                        "falling back to dynamic port",
+                        _name.c_str(),
+                        send_port,
+                        ip,
+                        port);
+        } else {
+            log_info("TCP %s: Using fixed send port %lu for %s:%lu", _name.c_str(), send_port, ip, port);
+        }
     }
 
     sockaddr.sin_family = AF_INET;
@@ -1603,7 +1723,7 @@ int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sock
     return fd;
 }
 
-bool TcpEndpoint::open(const std::string &ip, unsigned long port)
+bool TcpEndpoint::open(const std::string &ip, unsigned long port, unsigned long send_port)
 {
     this->is_ipv6 = ip_str_is_ipv6(ip.c_str());
 
@@ -1611,11 +1731,11 @@ bool TcpEndpoint::open(const std::string &ip, unsigned long port)
     struct sockaddr *sock;
     socklen_t addrlen;
     if (this->is_ipv6) {
-        fd = open_ipv6(ip.c_str(), port, this->sockaddr6);
+        fd = open_ipv6(ip.c_str(), port, this->sockaddr6, send_port);
         sock = (struct sockaddr *)&this->sockaddr6;
         addrlen = sizeof(sockaddr6);
     } else {
-        fd = open_ipv4(ip.c_str(), port, this->sockaddr);
+        fd = open_ipv4(ip.c_str(), port, this->sockaddr, send_port);
         sock = (struct sockaddr *)&this->sockaddr;
         addrlen = sizeof(sockaddr);
     }
@@ -1779,6 +1899,11 @@ bool TcpEndpoint::validate_config(const TcpEndpointConfig &config)
         log_error("TcpEndpoint %s: Invalid or unset TCP port %lu",
                   config.name.c_str(),
                   config.port);
+        return false;
+    }
+
+    if (config.send_port > 65535) {
+        log_error("TcpEndpoint %s: Invalid send port %lu", config.name.c_str(), config.send_port);
         return false;
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -81,7 +81,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, address)},
     {"mode",            true,   UdpEndpoint::parse_udp_mode,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, mode)},
     {"port",            false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, port)},
-    {"SourcePort",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, send_port)},
+    {"SourcePort",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, source_port)},
     {"filter",          false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)}, // legacy AllowMsgIdOut
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, block_msg_id_out)},
@@ -103,7 +103,7 @@ const char *TcpEndpoint::section_pattern = "tcpendpoint *";
 const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"address",         true,   ConfFile::parse_stdstring,      OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, address)},
     {"port",            true,   ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, port)},
-    {"SourcePort",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, send_port)},
+    {"SourcePort",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, source_port)},
     {"RetryTimeout",    false,  ConfFile::parse_i,              OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, retry_timeout)},
     {"AllowMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, allow_msg_id_out)},
     {"BlockMsgIdOut",   false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, block_msg_id_out)},
@@ -1084,12 +1084,12 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
         return false;
     }
 
-    if (conf.mode == UdpEndpointConfig::Mode::Server && conf.send_port != 0) {
+    if (conf.mode == UdpEndpointConfig::Mode::Server && conf.source_port != 0) {
         log_warning("UDP %s: SourcePort is only used in client (normal) mode, ignoring it",
                     conf.name.c_str());
     }
 
-    if (!this->open(conf.address.c_str(), conf.port, conf.mode, conf.send_port)) {
+    if (!this->open(conf.address.c_str(), conf.port, conf.mode, conf.source_port)) {
         log_error("Could not open %s:%ld", conf.address.c_str(), conf.port);
         return false;
     }
@@ -1138,7 +1138,7 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
 }
 
 int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
-                           unsigned long send_port)
+                           unsigned long source_port)
 {
     fd = socket(AF_INET6, SOCK_DGRAM, 0);
     if (fd < 0) {
@@ -1190,21 +1190,21 @@ int UdpEndpoint::open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig
     /* Bind a fixed local (send) port for client mode, if requested.
      * The socket is bound to any local interface.
      * On failure, warn and fall back to a dynamic (OS-assigned) port. */
-    if (mode == UdpEndpointConfig::Mode::Client && send_port != 0) {
+    if (mode == UdpEndpointConfig::Mode::Client && source_port != 0) {
         struct sockaddr_in6 bind_addr {};
         bind_addr.sin6_family = AF_INET6;
-        bind_addr.sin6_port = htons(send_port);
+        bind_addr.sin6_port = htons(source_port);
         bind_addr.sin6_addr = in6addr_any;
 
         if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
             log_warning("UDP %s: Could not bind fixed send port %lu for [%s]:%lu (%m), "
                         "falling back to dynamic port",
                         _name.c_str(),
-                        send_port,
+                        source_port,
                         ip_str,
                         port);
         } else {
-            log_info("UDP %s: Using fixed send port %lu", _name.c_str(), send_port);
+            log_info("UDP %s: Using fixed send port %lu", _name.c_str(), source_port);
         }
     }
 
@@ -1221,7 +1221,7 @@ fail:
 }
 
 int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
-                           unsigned long send_port)
+                           unsigned long source_port)
 {
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
@@ -1236,21 +1236,21 @@ int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig
     /* Bind a fixed local (send) port for client mode, if requested.
      * The socket is bound to any local interface.
      * On failure, warn and fall back to a dynamic (OS-assigned) port. */
-    if (mode == UdpEndpointConfig::Mode::Client && send_port != 0) {
+    if (mode == UdpEndpointConfig::Mode::Client && source_port != 0) {
         struct sockaddr_in bind_addr {};
         bind_addr.sin_family = AF_INET;
-        bind_addr.sin_port = htons(send_port);
+        bind_addr.sin_port = htons(source_port);
         bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
         if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
             log_warning("UDP %s: Could not bind fixed send port %lu for %s:%lu (%m), "
                         "falling back to dynamic port",
                         _name.c_str(),
-                        send_port,
+                        source_port,
                         ip,
                         port);
         } else {
-            log_info("UDP %s: Using fixed send port %lu for %s:%lu", _name.c_str(), send_port, ip, port);
+            log_info("UDP %s: Using fixed send port %lu for %s:%lu", _name.c_str(), source_port, ip, port);
         }
     }
 
@@ -1273,7 +1273,7 @@ fail:
 }
 
 bool UdpEndpoint::open(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
-                       unsigned long send_port)
+                       unsigned long source_port)
 {
     const int broadcast_val = 1;
 
@@ -1281,9 +1281,9 @@ bool UdpEndpoint::open(const char *ip, unsigned long port, UdpEndpointConfig::Mo
 
     // setup the special IPv6/IPv4 part
     if (this->is_ipv6) {
-        open_ipv6(ip, port, mode, send_port);
+        open_ipv6(ip, port, mode, source_port);
     } else {
-        open_ipv4(ip, port, mode, send_port);
+        open_ipv4(ip, port, mode, source_port);
     }
 
     if (fd < 0) {
@@ -1481,8 +1481,8 @@ bool UdpEndpoint::validate_config(const UdpEndpointConfig &config)
         return false;
     }
 
-    if (config.send_port > 65535) {
-        log_error("UdpEndpoint %s: Invalid send port %lu", config.name.c_str(), config.send_port);
+    if (config.source_port > 65535) {
+        log_error("UdpEndpoint %s: Invalid send port %lu", config.name.c_str(), config.source_port);
         return false;
     }
 
@@ -1514,7 +1514,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
     this->_ip = conf.address;
     this->_port = conf.port;
-    this->_send_port = conf.send_port;
+    this->_source_port = conf.source_port;
     this->_retry_timeout = conf.retry_timeout;
 
     for (auto msg_id : conf.allow_msg_id_out) {
@@ -1557,7 +1557,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
     this->_group_name = conf.group;
 
-    if (!this->open(conf.address, conf.port, conf.send_port)) {
+    if (!this->open(conf.address, conf.port, conf.source_port)) {
         log_warning("Could not open %s:%ld, re-trying every %d sec",
                     conf.address.c_str(),
                     conf.port,
@@ -1574,7 +1574,7 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
 
 bool TcpEndpoint::reopen()
 {
-    return this->open(_ip, _port, _send_port);
+    return this->open(_ip, _port, _source_port);
 }
 
 int TcpEndpoint::accept(int listener_fd)
@@ -1610,7 +1610,7 @@ int TcpEndpoint::accept(int listener_fd)
 }
 
 int TcpEndpoint::open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6,
-                           unsigned long send_port)
+                           unsigned long source_port)
 {
     auto fd = socket(AF_INET6, SOCK_STREAM, 0);
     if (fd == -1) {
@@ -1640,10 +1640,10 @@ int TcpEndpoint::open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &soc
     /* Bind a fixed local (send) port, if requested. The socket is bound to
      * any local interface. On failure, warn and fall back to a dynamic
      * (OS-assigned) port. */
-    if (send_port != 0) {
+    if (source_port != 0) {
         struct sockaddr_in6 bind_addr {};
         bind_addr.sin6_family = AF_INET6;
-        bind_addr.sin6_port = htons(send_port);
+        bind_addr.sin6_port = htons(source_port);
         bind_addr.sin6_addr = in6addr_any;
 
         /* allow rebinding the same send port on reconnect, while old sockets
@@ -1652,18 +1652,18 @@ int TcpEndpoint::open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &soc
         if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
             log_warning("TCP %s: Could not set SO_REUSEADDR for fixed send port %lu (%m)",
                         _name.c_str(),
-                        send_port);
+                        source_port);
         }
 
         if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
             log_warning("TCP %s: Could not bind fixed send port %lu for [%s]:%lu (%m), "
                         "falling back to dynamic port",
                         _name.c_str(),
-                        send_port,
+                        source_port,
                         ip_str,
                         port);
         } else {
-            log_info("TCP %s: Using fixed send port %lu", _name.c_str(), send_port);
+            log_info("TCP %s: Using fixed send port %lu", _name.c_str(), source_port);
         }
     }
 
@@ -1678,7 +1678,7 @@ fail:
 }
 
 int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr,
-                           unsigned long send_port)
+                           unsigned long source_port)
 {
     auto fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1) {
@@ -1689,10 +1689,10 @@ int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sock
     /* Bind a fixed local (send) port, if requested. The socket is bound to
      * any local interface. On failure, warn and fall back to a dynamic
      * (OS-assigned) port. */
-    if (send_port != 0) {
+    if (source_port != 0) {
         struct sockaddr_in bind_addr {};
         bind_addr.sin_family = AF_INET;
-        bind_addr.sin_port = htons(send_port);
+        bind_addr.sin_port = htons(source_port);
         bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
         /* allow rebinding the same send port on reconnect, while old sockets
@@ -1701,18 +1701,18 @@ int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sock
         if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
             log_warning("TCP %s: Could not set SO_REUSEADDR for fixed send port %lu (%m)",
                         _name.c_str(),
-                        send_port);
+                        source_port);
         }
 
         if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
             log_warning("TCP %s: Could not bind fixed send port %lu for %s:%lu (%m), "
                         "falling back to dynamic port",
                         _name.c_str(),
-                        send_port,
+                        source_port,
                         ip,
                         port);
         } else {
-            log_info("TCP %s: Using fixed send port %lu for %s:%lu", _name.c_str(), send_port, ip, port);
+            log_info("TCP %s: Using fixed send port %lu for %s:%lu", _name.c_str(), source_port, ip, port);
         }
     }
 
@@ -1723,7 +1723,7 @@ int TcpEndpoint::open_ipv4(const char *ip, unsigned long port, sockaddr_in &sock
     return fd;
 }
 
-bool TcpEndpoint::open(const std::string &ip, unsigned long port, unsigned long send_port)
+bool TcpEndpoint::open(const std::string &ip, unsigned long port, unsigned long source_port)
 {
     this->is_ipv6 = ip_str_is_ipv6(ip.c_str());
 
@@ -1731,11 +1731,11 @@ bool TcpEndpoint::open(const std::string &ip, unsigned long port, unsigned long 
     struct sockaddr *sock;
     socklen_t addrlen;
     if (this->is_ipv6) {
-        fd = open_ipv6(ip.c_str(), port, this->sockaddr6, send_port);
+        fd = open_ipv6(ip.c_str(), port, this->sockaddr6, source_port);
         sock = (struct sockaddr *)&this->sockaddr6;
         addrlen = sizeof(sockaddr6);
     } else {
-        fd = open_ipv4(ip.c_str(), port, this->sockaddr, send_port);
+        fd = open_ipv4(ip.c_str(), port, this->sockaddr, source_port);
         sock = (struct sockaddr *)&this->sockaddr;
         addrlen = sizeof(sockaddr);
     }
@@ -1902,8 +1902,8 @@ bool TcpEndpoint::validate_config(const TcpEndpointConfig &config)
         return false;
     }
 
-    if (config.send_port > 65535) {
-        log_error("TcpEndpoint %s: Invalid send port %lu", config.name.c_str(), config.send_port);
+    if (config.source_port > 65535) {
+        log_error("TcpEndpoint %s: Invalid send port %lu", config.name.c_str(), config.source_port);
         return false;
     }
 

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -63,7 +63,7 @@ struct UdpEndpointConfig {
     std::string address;
     unsigned long port;
     Mode mode;
-    unsigned long send_port{0};
+    unsigned long source_port{0};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint32_t> block_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
@@ -83,7 +83,7 @@ struct TcpEndpointConfig {
     std::string name;
     std::string address;
     unsigned long port;
-    unsigned long send_port{0};
+    unsigned long source_port{0};
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint32_t> block_msg_id_out;
@@ -342,11 +342,11 @@ public:
 protected:
     bool open(const char *ip, unsigned long port,
               UdpEndpointConfig::Mode mode = UdpEndpointConfig::Mode::Client,
-              unsigned long send_port = 0);
+              unsigned long source_port = 0);
     int open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
-                  unsigned long send_port);
+                  unsigned long source_port);
     int open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
-                  unsigned long send_port);
+                  unsigned long source_port);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
@@ -386,11 +386,11 @@ public:
     static bool validate_config(const TcpEndpointConfig &config);
 
 protected:
-    bool open(const std::string &ip, unsigned long port, unsigned long send_port = 0);
+    bool open(const std::string &ip, unsigned long port, unsigned long source_port = 0);
     int open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr,
-                  unsigned long send_port);
+                  unsigned long source_port);
     int open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6,
-                  unsigned long send_port);
+                  unsigned long source_port);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
@@ -400,7 +400,7 @@ protected:
 private:
     std::string _ip{};
     unsigned long _port = 0;
-    unsigned long _send_port = 0;
+    unsigned long _source_port = 0;
     bool _valid = true;
 
     bool is_ipv6;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -63,6 +63,7 @@ struct UdpEndpointConfig {
     std::string address;
     unsigned long port;
     Mode mode;
+    unsigned long send_port{0};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint32_t> block_msg_id_out;
     std::vector<uint8_t> allow_src_comp_out;
@@ -82,6 +83,7 @@ struct TcpEndpointConfig {
     std::string name;
     std::string address;
     unsigned long port;
+    unsigned long send_port{0};
     int retry_timeout{5};
     std::vector<uint32_t> allow_msg_id_out;
     std::vector<uint32_t> block_msg_id_out;
@@ -339,9 +341,12 @@ public:
 
 protected:
     bool open(const char *ip, unsigned long port,
-              UdpEndpointConfig::Mode mode = UdpEndpointConfig::Mode::Client);
-    int open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode);
-    int open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode);
+              UdpEndpointConfig::Mode mode = UdpEndpointConfig::Mode::Client,
+              unsigned long send_port = 0);
+    int open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
+                  unsigned long send_port);
+    int open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode,
+                  unsigned long send_port);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
@@ -381,9 +386,11 @@ public:
     static bool validate_config(const TcpEndpointConfig &config);
 
 protected:
-    bool open(const std::string &ip, unsigned long port);
-    static int open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr);
-    static int open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6);
+    bool open(const std::string &ip, unsigned long port, unsigned long send_port = 0);
+    int open_ipv4(const char *ip, unsigned long port, sockaddr_in &sockaddr,
+                  unsigned long send_port);
+    int open_ipv6(const char *ip, unsigned long port, sockaddr_in6 &sockaddr6,
+                  unsigned long send_port);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
@@ -393,6 +400,7 @@ protected:
 private:
     std::string _ip{};
     unsigned long _port = 0;
+    unsigned long _send_port = 0;
     bool _valid = true;
 
     bool is_ipv6;

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -658,21 +658,21 @@ TEST(UdpEndpointTest, ConfigValidateSourcePort)
     config.mode = UdpEndpointConfig::Mode::Client;
 
     // unset send port (dynamic port) is valid
-    config.send_port = 0;
+    config.source_port = 0;
     EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with unset send port";
 
     // valid send ports
-    config.send_port = 1;
+    config.source_port = 1;
     EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with send port 1";
 
-    config.send_port = 65535;
+    config.source_port = 65535;
     EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with send port 65535";
 
     // invalid send ports
-    config.send_port = 65536;
+    config.source_port = 65536;
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with send port 65536";
 
-    config.send_port = ULONG_MAX;
+    config.source_port = ULONG_MAX;
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with send port ULONG_MAX";
 }
 
@@ -680,14 +680,14 @@ TEST(UdpEndpointTest, FixedSourcePortBind)
 {
     Mainloop &mainloop = Mainloop::init();
 
-    const unsigned long send_port = 45870;
+    const unsigned long source_port = 45870;
 
     UdpEndpointConfig config{};
     config.name = "fixed-send-port";
     config.mode = UdpEndpointConfig::Mode::Client;
     config.address = "127.0.0.1";
     config.port = 14550;
-    config.send_port = send_port;
+    config.source_port = source_port;
 
     UdpEndpoint udp{config.name};
     ASSERT_TRUE(udp.setup(config));
@@ -695,7 +695,7 @@ TEST(UdpEndpointTest, FixedSourcePortBind)
     struct sockaddr_in addr {};
     socklen_t addrlen = sizeof(addr);
     ASSERT_EQ(getsockname(udp.fd, (struct sockaddr *)&addr, &addrlen), 0);
-    EXPECT_EQ(ntohs(addr.sin_port), send_port);
+    EXPECT_EQ(ntohs(addr.sin_port), source_port);
 
     mainloop.teardown();
 }
@@ -704,14 +704,14 @@ TEST(UdpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
 {
     Mainloop &mainloop = Mainloop::init();
 
-    const unsigned long send_port = 45871;
+    const unsigned long source_port = 45871;
 
     UdpEndpointConfig config{};
     config.name = "conflicting-send-port";
     config.mode = UdpEndpointConfig::Mode::Client;
     config.address = "127.0.0.1";
     config.port = 14550;
-    config.send_port = send_port;
+    config.source_port = source_port;
 
     // occupy the requested send port, so the bind of the endpoint fails
     int blocker_fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -719,7 +719,7 @@ TEST(UdpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
     struct sockaddr_in blocker_addr {};
     blocker_addr.sin_family = AF_INET;
     blocker_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-    blocker_addr.sin_port = htons(send_port);
+    blocker_addr.sin_port = htons(source_port);
     ASSERT_EQ(bind(blocker_fd, (struct sockaddr *)&blocker_addr, sizeof(blocker_addr)), 0);
 
     UdpEndpoint udp{config.name};
@@ -728,7 +728,7 @@ TEST(UdpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
     struct sockaddr_in addr {};
     socklen_t addrlen = sizeof(addr);
     ASSERT_EQ(getsockname(udp.fd, (struct sockaddr *)&addr, &addrlen), 0);
-    EXPECT_NE(ntohs(addr.sin_port), send_port);
+    EXPECT_NE(ntohs(addr.sin_port), source_port);
 
     close(blocker_fd);
     mainloop.teardown();
@@ -806,21 +806,21 @@ TEST(TcpEndpointTest, ConfigValidateSourcePort)
     config.port = 14550;
 
     // unset send port (dynamic port) is valid
-    config.send_port = 0;
+    config.source_port = 0;
     EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with unset send port";
 
     // valid send ports
-    config.send_port = 1;
+    config.source_port = 1;
     EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with send port 1";
 
-    config.send_port = 65535;
+    config.source_port = 65535;
     EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with send port 65535";
 
     // invalid send ports
-    config.send_port = 65536;
+    config.source_port = 65536;
     EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with send port 65536";
 
-    config.send_port = ULONG_MAX;
+    config.source_port = ULONG_MAX;
     EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with send port ULONG_MAX";
 }
 
@@ -852,7 +852,7 @@ TEST(TcpEndpointTest, FixedSourcePortBind)
 {
     Mainloop &mainloop = Mainloop::init();
 
-    const unsigned long send_port = 45874;
+    const unsigned long source_port = 45874;
     unsigned long server_port = 0;
 
     int listener_fd = create_tcp_listener(server_port);
@@ -862,7 +862,7 @@ TEST(TcpEndpointTest, FixedSourcePortBind)
     config.name = "fixed-send-port";
     config.address = "127.0.0.1";
     config.port = server_port;
-    config.send_port = send_port;
+    config.source_port = source_port;
     config.retry_timeout = 0;
 
     TcpEndpoint tcp{config.name};
@@ -872,7 +872,7 @@ TEST(TcpEndpointTest, FixedSourcePortBind)
     struct sockaddr_in addr {};
     socklen_t addrlen = sizeof(addr);
     ASSERT_EQ(getsockname(tcp.fd, (struct sockaddr *)&addr, &addrlen), 0);
-    EXPECT_EQ(ntohs(addr.sin_port), send_port);
+    EXPECT_EQ(ntohs(addr.sin_port), source_port);
 
     // close before mainloop teardown, b/c close() removes the fd from the mainloop
     tcp.close();
@@ -884,7 +884,7 @@ TEST(TcpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
 {
     Mainloop &mainloop = Mainloop::init();
 
-    const unsigned long send_port = 45875;
+    const unsigned long source_port = 45875;
     unsigned long server_port = 0;
 
     int listener_fd = create_tcp_listener(server_port);
@@ -896,14 +896,14 @@ TEST(TcpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
     struct sockaddr_in blocker_addr {};
     blocker_addr.sin_family = AF_INET;
     blocker_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-    blocker_addr.sin_port = htons(send_port);
+    blocker_addr.sin_port = htons(source_port);
     ASSERT_EQ(bind(blocker_fd, (struct sockaddr *)&blocker_addr, sizeof(blocker_addr)), 0);
 
     TcpEndpointConfig config{};
     config.name = "conflicting-send-port";
     config.address = "127.0.0.1";
     config.port = server_port;
-    config.send_port = send_port;
+    config.source_port = source_port;
     config.retry_timeout = 0;
 
     TcpEndpoint tcp{config.name};
@@ -913,7 +913,7 @@ TEST(TcpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
     struct sockaddr_in addr {};
     socklen_t addrlen = sizeof(addr);
     ASSERT_EQ(getsockname(tcp.fd, (struct sockaddr *)&addr, &addrlen), 0);
-    EXPECT_NE(ntohs(addr.sin_port), send_port);
+    EXPECT_NE(ntohs(addr.sin_port), source_port);
 
     // close before mainloop teardown, b/c close() removes the fd from the mainloop
     tcp.close();

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -650,7 +650,7 @@ TEST(UdpEndpointTest, ConfigValidateMode)
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with Undefined mode";
 }
 
-TEST(UdpEndpointTest, ConfigValidateSendPort)
+TEST(UdpEndpointTest, ConfigValidateSourcePort)
 {
     UdpEndpointConfig config;
     config.address = "127.0.0.1";
@@ -676,7 +676,7 @@ TEST(UdpEndpointTest, ConfigValidateSendPort)
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with send port ULONG_MAX";
 }
 
-TEST(UdpEndpointTest, FixedSendPortBind)
+TEST(UdpEndpointTest, FixedSourcePortBind)
 {
     Mainloop &mainloop = Mainloop::init();
 
@@ -700,7 +700,7 @@ TEST(UdpEndpointTest, FixedSendPortBind)
     mainloop.teardown();
 }
 
-TEST(UdpEndpointTest, FixedSendPortConflictFallsBackToDynamic)
+TEST(UdpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
 {
     Mainloop &mainloop = Mainloop::init();
 
@@ -799,7 +799,7 @@ TEST(TcpEndpointTest, ConfigValidatePort)
         << "with port " << std::to_string(config.port);
 }
 
-TEST(TcpEndpointTest, ConfigValidateSendPort)
+TEST(TcpEndpointTest, ConfigValidateSourcePort)
 {
     TcpEndpointConfig config;
     config.address = "127.0.0.1";
@@ -848,7 +848,7 @@ static int create_tcp_listener(unsigned long &server_port)
     return listener_fd;
 }
 
-TEST(TcpEndpointTest, FixedSendPortBind)
+TEST(TcpEndpointTest, FixedSourcePortBind)
 {
     Mainloop &mainloop = Mainloop::init();
 
@@ -880,7 +880,7 @@ TEST(TcpEndpointTest, FixedSendPortBind)
     mainloop.teardown();
 }
 
-TEST(TcpEndpointTest, FixedSendPortConflictFallsBackToDynamic)
+TEST(TcpEndpointTest, FixedSourcePortConflictFallsBackToDynamic)
 {
     Mainloop &mainloop = Mainloop::init();
 

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -19,6 +19,7 @@
 #include "autolog.h"
 #include "binlog.h"
 #include "endpoint.h"
+#include "mainloop.h"
 #include "tlog.h"
 #include "ulog.h"
 
@@ -649,6 +650,90 @@ TEST(UdpEndpointTest, ConfigValidateMode)
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with Undefined mode";
 }
 
+TEST(UdpEndpointTest, ConfigValidateSendPort)
+{
+    UdpEndpointConfig config;
+    config.address = "127.0.0.1";
+    config.port = 14550;
+    config.mode = UdpEndpointConfig::Mode::Client;
+
+    // unset send port (dynamic port) is valid
+    config.send_port = 0;
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with unset send port";
+
+    // valid send ports
+    config.send_port = 1;
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with send port 1";
+
+    config.send_port = 65535;
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with send port 65535";
+
+    // invalid send ports
+    config.send_port = 65536;
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with send port 65536";
+
+    config.send_port = ULONG_MAX;
+    EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with send port ULONG_MAX";
+}
+
+TEST(UdpEndpointTest, FixedSendPortBind)
+{
+    Mainloop &mainloop = Mainloop::init();
+
+    const unsigned long send_port = 45870;
+
+    UdpEndpointConfig config{};
+    config.name = "fixed-send-port";
+    config.mode = UdpEndpointConfig::Mode::Client;
+    config.address = "127.0.0.1";
+    config.port = 14550;
+    config.send_port = send_port;
+
+    UdpEndpoint udp{config.name};
+    ASSERT_TRUE(udp.setup(config));
+
+    struct sockaddr_in addr {};
+    socklen_t addrlen = sizeof(addr);
+    ASSERT_EQ(getsockname(udp.fd, (struct sockaddr *)&addr, &addrlen), 0);
+    EXPECT_EQ(ntohs(addr.sin_port), send_port);
+
+    mainloop.teardown();
+}
+
+TEST(UdpEndpointTest, FixedSendPortConflictFallsBackToDynamic)
+{
+    Mainloop &mainloop = Mainloop::init();
+
+    const unsigned long send_port = 45871;
+
+    UdpEndpointConfig config{};
+    config.name = "conflicting-send-port";
+    config.mode = UdpEndpointConfig::Mode::Client;
+    config.address = "127.0.0.1";
+    config.port = 14550;
+    config.send_port = send_port;
+
+    // occupy the requested send port, so the bind of the endpoint fails
+    int blocker_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(blocker_fd, 0);
+    struct sockaddr_in blocker_addr {};
+    blocker_addr.sin_family = AF_INET;
+    blocker_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    blocker_addr.sin_port = htons(send_port);
+    ASSERT_EQ(bind(blocker_fd, (struct sockaddr *)&blocker_addr, sizeof(blocker_addr)), 0);
+
+    UdpEndpoint udp{config.name};
+    EXPECT_TRUE(udp.setup(config)) << "should fall back to a dynamic port";
+
+    struct sockaddr_in addr {};
+    socklen_t addrlen = sizeof(addr);
+    ASSERT_EQ(getsockname(udp.fd, (struct sockaddr *)&addr, &addrlen), 0);
+    EXPECT_NE(ntohs(addr.sin_port), send_port);
+
+    close(blocker_fd);
+    mainloop.teardown();
+}
+
 /**
  * TCP Endpoint
  */
@@ -712,6 +797,129 @@ TEST(TcpEndpointTest, ConfigValidatePort)
     config.port = 0;
     EXPECT_FALSE(TcpEndpoint::validate_config(config))
         << "with port " << std::to_string(config.port);
+}
+
+TEST(TcpEndpointTest, ConfigValidateSendPort)
+{
+    TcpEndpointConfig config;
+    config.address = "127.0.0.1";
+    config.port = 14550;
+
+    // unset send port (dynamic port) is valid
+    config.send_port = 0;
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with unset send port";
+
+    // valid send ports
+    config.send_port = 1;
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with send port 1";
+
+    config.send_port = 65535;
+    EXPECT_TRUE(TcpEndpoint::validate_config(config)) << "with send port 65535";
+
+    // invalid send ports
+    config.send_port = 65536;
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with send port 65536";
+
+    config.send_port = ULONG_MAX;
+    EXPECT_FALSE(TcpEndpoint::validate_config(config)) << "with send port ULONG_MAX";
+}
+
+// Create a local TCP server on 127.0.0.1 with an ephemeral port and return its fd,
+// storing the bound port in @server_port. Assertion failures mark it invalid.
+static int create_tcp_listener(unsigned long &server_port)
+{
+    int listener_fd = socket(AF_INET, SOCK_STREAM, 0);
+    EXPECT_GE(listener_fd, 0);
+    if (listener_fd < 0) {
+        return -1;
+    }
+
+    struct sockaddr_in addr {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    EXPECT_EQ(bind(listener_fd, (struct sockaddr *)&addr, sizeof(addr)), 0);
+    EXPECT_EQ(listen(listener_fd, 1), 0);
+
+    socklen_t addrlen = sizeof(addr);
+    EXPECT_EQ(getsockname(listener_fd, (struct sockaddr *)&addr, &addrlen), 0);
+    server_port = ntohs(addr.sin_port);
+
+    return listener_fd;
+}
+
+TEST(TcpEndpointTest, FixedSendPortBind)
+{
+    Mainloop &mainloop = Mainloop::init();
+
+    const unsigned long send_port = 45874;
+    unsigned long server_port = 0;
+
+    int listener_fd = create_tcp_listener(server_port);
+    ASSERT_GE(listener_fd, 0);
+
+    TcpEndpointConfig config{};
+    config.name = "fixed-send-port";
+    config.address = "127.0.0.1";
+    config.port = server_port;
+    config.send_port = send_port;
+    config.retry_timeout = 0;
+
+    TcpEndpoint tcp{config.name};
+    ASSERT_TRUE(tcp.setup(config));
+    ASSERT_GE(tcp.fd, 0) << "endpoint should be connected to the local test server";
+
+    struct sockaddr_in addr {};
+    socklen_t addrlen = sizeof(addr);
+    ASSERT_EQ(getsockname(tcp.fd, (struct sockaddr *)&addr, &addrlen), 0);
+    EXPECT_EQ(ntohs(addr.sin_port), send_port);
+
+    // close before mainloop teardown, b/c close() removes the fd from the mainloop
+    tcp.close();
+    close(listener_fd);
+    mainloop.teardown();
+}
+
+TEST(TcpEndpointTest, FixedSendPortConflictFallsBackToDynamic)
+{
+    Mainloop &mainloop = Mainloop::init();
+
+    const unsigned long send_port = 45875;
+    unsigned long server_port = 0;
+
+    int listener_fd = create_tcp_listener(server_port);
+    ASSERT_GE(listener_fd, 0);
+
+    // occupy the requested send port, so the bind of the endpoint fails
+    int blocker_fd = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(blocker_fd, 0);
+    struct sockaddr_in blocker_addr {};
+    blocker_addr.sin_family = AF_INET;
+    blocker_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    blocker_addr.sin_port = htons(send_port);
+    ASSERT_EQ(bind(blocker_fd, (struct sockaddr *)&blocker_addr, sizeof(blocker_addr)), 0);
+
+    TcpEndpointConfig config{};
+    config.name = "conflicting-send-port";
+    config.address = "127.0.0.1";
+    config.port = server_port;
+    config.send_port = send_port;
+    config.retry_timeout = 0;
+
+    TcpEndpoint tcp{config.name};
+    EXPECT_TRUE(tcp.setup(config)) << "should fall back to a dynamic port";
+    ASSERT_GE(tcp.fd, 0) << "endpoint should be connected to the local test server";
+
+    struct sockaddr_in addr {};
+    socklen_t addrlen = sizeof(addr);
+    ASSERT_EQ(getsockname(tcp.fd, (struct sockaddr *)&addr, &addrlen), 0);
+    EXPECT_NE(ntohs(addr.sin_port), send_port);
+
+    // close before mainloop teardown, b/c close() removes the fd from the mainloop
+    tcp.close();
+    close(blocker_fd);
+    close(listener_fd);
+    mainloop.teardown();
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,12 +71,12 @@ static void help(FILE *fp)
         "                               continues increasing not to collide with previous\n"
         "                               ports. 'normal' mode. Optionally, a fixed local\n"
         "                               send port can be appended after '@' as\n"
-        "                               <sendport>, e.g. 192.168.7.1:14550@14580. If the\n"
+        "                               <sourceport>, e.g. 192.168.7.1:14550@14580. If the\n"
         "                               send port can't be bound (e.g. already in use),\n"
         "                               a dynamic port is used instead\n"
         "  -p --tcp-endpoint <ip:port>  Add TCP endpoint client, which will connect to given\n"
         "                               address. Optionally, a fixed local send port can\n"
-        "                               be appended after '@' as <sendport>, e.g.\n"
+        "                               be appended after '@' as <sourceport>, e.g.\n"
         "                               192.168.7.1:14550@14580. If the send port can't\n"
         "                               be bound (e.g. already in use), a dynamic port is\n"
         "                               used instead\n"
@@ -229,7 +229,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             opt_udp.mode = UdpEndpointConfig::Mode::Client;
 
             // Optional fixed local send port, separated from the target by '@':
-            // <ip[:port]>[@<sendport>], where <sendport> is a plain port number
+            // <ip[:port]>[@<sourceport>], where <sourceport> is a plain port number
             // (e.g. 14580). The socket is always bound to any local interface.
             char *arg = strdup(optarg);
             char *send_spec = strrchr(arg, '@');
@@ -330,7 +330,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             opt_tcp.name = "CLI";
 
             // Optional fixed local send port, separated from the target by '@':
-            // <ip:port>[@<sendport>], where <sendport> is a plain port number
+            // <ip:port>[@<sourceport>], where <sourceport> is a plain port number
             // (e.g. 14580). The socket is always bound to any local interface.
             char *arg = strdup(optarg);
             char *send_spec = strrchr(arg, '@');

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,9 +69,17 @@ static void help(FILE *fp)
         "  -e --endpoint <ip[:port]>    Add UDP endpoint to communicate. Port is optional\n"
         "                               and in case it's not given it starts in 14550 and\n"
         "                               continues increasing not to collide with previous\n"
-        "                               ports. 'normal' mode\n"
+        "                               ports. 'normal' mode. Optionally, a fixed local\n"
+        "                               send port can be appended after '@' as\n"
+        "                               <sendport>, e.g. 192.168.7.1:14550@14580. If the\n"
+        "                               send port can't be bound (e.g. already in use),\n"
+        "                               a dynamic port is used instead\n"
         "  -p --tcp-endpoint <ip:port>  Add TCP endpoint client, which will connect to given\n"
-        "                               address\n"
+        "                               address. Optionally, a fixed local send port can\n"
+        "                               be appended after '@' as <sendport>, e.g.\n"
+        "                               192.168.7.1:14550@14580. If the send port can't\n"
+        "                               be bound (e.g. already in use), a dynamic port is\n"
+        "                               used instead\n"
         "  -r --report_msg_statistics   Report message statistics\n"
         "  -t --tcp-port <port>         Port in which mavlink-router will listen for TCP\n"
         "                               connections. Pass 0 to disable TCP listening.\n"
@@ -121,6 +129,25 @@ static int split_on_last_colon(const char *str, char **base, unsigned long *numb
             return -EINVAL;
         }
     }
+
+    return 0;
+}
+
+/*
+ * Parse a fixed local (send) port spec for UDP/TCP client endpoints.
+ * The socket is always bound to any local interface, so only a plain port
+ * number is accepted (e.g. 14580).
+ */
+static int parse_send_port_spec(const char *spec, unsigned long &send_port)
+{
+    unsigned long port;
+
+    if (safe_atoul(spec, &port) < 0 || port == 0 || port > 65535) {
+        log_error("Invalid send port in argument: %s (must be within 1-65535)", spec);
+        return -EINVAL;
+    }
+
+    send_port = port;
 
     return 0;
 }
@@ -201,8 +228,32 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             opt_udp.name = "CLI";
             opt_udp.mode = UdpEndpointConfig::Mode::Client;
 
-            if (split_on_last_colon(optarg, &ip, &port) < 0) {
+            // Optional fixed local send port, separated from the target by '@':
+            // <ip[:port]>[@<sendport>], where <sendport> is a plain port number
+            // (e.g. 14580). The socket is always bound to any local interface.
+            char *arg = strdup(optarg);
+            char *send_spec = strrchr(arg, '@');
+            if (send_spec != nullptr) {
+                *send_spec = '\0';
+                send_spec++;
+
+                if (*arg == '\0' || *send_spec == '\0') {
+                    log_error("Invalid endpoint argument: %s", optarg);
+                    free(arg);
+                    help(stderr);
+                    return -EINVAL;
+                }
+
+                if (parse_send_port_spec(send_spec, opt_udp.send_port) < 0) {
+                    free(arg);
+                    help(stderr); // error message was already logged
+                    return -EINVAL;
+                }
+            }
+
+            if (split_on_last_colon(arg, &ip, &port) < 0) {
                 log_error("Invalid port in argument: %s", optarg);
+                free(arg);
                 help(stderr);
                 return -EINVAL;
             }
@@ -216,6 +267,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
 
             if (!UdpEndpoint::validate_config(opt_udp)) {
                 free(ip);
+                free(arg);
                 help(stderr); // error message was already logged by validate_config()
                 return -EINVAL;
             }
@@ -223,6 +275,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             config.udp_configs.push_back(opt_udp);
 
             free(ip);
+            free(arg);
             break;
         }
         case 'r': {
@@ -276,8 +329,32 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             TcpEndpointConfig opt_tcp{};
             opt_tcp.name = "CLI";
 
-            if (split_on_last_colon(optarg, &ip, &port) < 0) {
+            // Optional fixed local send port, separated from the target by '@':
+            // <ip:port>[@<sendport>], where <sendport> is a plain port number
+            // (e.g. 14580). The socket is always bound to any local interface.
+            char *arg = strdup(optarg);
+            char *send_spec = strrchr(arg, '@');
+            if (send_spec != nullptr) {
+                *send_spec = '\0';
+                send_spec++;
+
+                if (*arg == '\0' || *send_spec == '\0') {
+                    log_error("Invalid endpoint argument: %s", optarg);
+                    free(arg);
+                    help(stderr);
+                    return -EINVAL;
+                }
+
+                if (parse_send_port_spec(send_spec, opt_tcp.send_port) < 0) {
+                    free(arg);
+                    help(stderr); // error message was already logged
+                    return -EINVAL;
+                }
+            }
+
+            if (split_on_last_colon(arg, &ip, &port) < 0) {
                 log_error("Invalid port in argument: %s", optarg);
+                free(arg);
                 help(stderr);
                 return -EINVAL;
             }
@@ -286,6 +363,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             if (ULONG_MAX == opt_tcp.port) {
                 log_error("Missing port in argument: %s", optarg);
                 free(ip);
+                free(arg);
                 help(stderr);
                 return -EINVAL;
             }
@@ -294,6 +372,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
 
             if (!TcpEndpoint::validate_config(opt_tcp)) {
                 free(ip);
+                free(arg);
                 help(stderr); // error message was already logged by validate_config()
                 return -EINVAL;
             }
@@ -301,6 +380,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
             config.tcp_configs.push_back(opt_tcp);
 
             free(ip);
+            free(arg);
             break;
         }
         case 'c':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ static int split_on_last_colon(const char *str, char **base, unsigned long *numb
  * The socket is always bound to any local interface, so only a plain port
  * number is accepted (e.g. 14580).
  */
-static int parse_send_port_spec(const char *spec, unsigned long &send_port)
+static int parse_source_port_spec(const char *spec, unsigned long &source_port)
 {
     unsigned long port;
 
@@ -147,7 +147,7 @@ static int parse_send_port_spec(const char *spec, unsigned long &send_port)
         return -EINVAL;
     }
 
-    send_port = port;
+    source_port = port;
 
     return 0;
 }
@@ -244,7 +244,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
                     return -EINVAL;
                 }
 
-                if (parse_send_port_spec(send_spec, opt_udp.send_port) < 0) {
+                if (parse_source_port_spec(send_spec, opt_udp.source_port) < 0) {
                     free(arg);
                     help(stderr); // error message was already logged
                     return -EINVAL;
@@ -345,7 +345,7 @@ static int parse_argv(int argc, char *argv[], Configuration &config)
                     return -EINVAL;
                 }
 
-                if (parse_send_port_spec(send_spec, opt_tcp.send_port) < 0) {
+                if (parse_source_port_spec(send_spec, opt_tcp.source_port) < 0) {
                     free(arg);
                     help(stderr); // error message was already logged
                     return -EINVAL;


### PR DESCRIPTION
I encountered a situation where I needed the static ports opened for Udp/Tcp endpoints. For these specific usage configuration that can be control static port usage gonna be good for users. For this reason, I implemented changes to allow the source port to be set via configuration. 

### What Changes
- Added source_port to configuration (UdpEndpointConfig & TcpEndpointConfig). Set it default to 0. (0 means keep dynamic behavior)
- Added logic for binding port to static port that given in configuration. Also added fallback logic when binding static fails, it keeps logic in default behavior.
- Added SourcePort key value parsing for configuration file parsing and updated config file examples.
- For CLI configuration, I added support strings like \<ip>:\<port>@\<sourceport>.